### PR TITLE
Fix for Update-Module fails with ModuleAuthenticodeSignature error for modules with signed PSD1

### DIFF
--- a/PowerShellGet/PSGet.Resource.psd1
+++ b/PowerShellGet/PSGet.Resource.psd1
@@ -225,6 +225,7 @@ ConvertFrom-StringData @'
         CatalogFileNotFoundInAvailableModule=Catalog file '{0}' is not found in the contents of the previously-installed module '{1}' with the same name.
         CatalogFileNotFoundInNewModule=Catalog file '{0}' is not found in the contents of the module '{1}' being installed.
         ValidAuthenticodeSignature=Valid authenticode signature found in the catalog file '{0}' for the module '{1}'.
+        ValidAuthenticodeSignatureInFile=Valid authenticode signature found in the file '{0}' for the module '{1}'.
         ValidatingCatalogSignature=Validating the '{0}' module files for catalog signing using the catalog file '{1}'.
         AuthenticodeIssuerMatch=Authenticode issuer '{0}' of the new module '{1}' with version '{2}' matches with the authenticode issuer '{3}' of the previously-installed module '{4}' with version '{5}'.
         ValidCatalogSignature=The catalog signature in '{0}' of the module '{1}' is valid and matches with the hash generated from the module contents.

--- a/PowerShellGet/PowerShellGet.psd1
+++ b/PowerShellGet/PowerShellGet.psd1
@@ -1,6 +1,6 @@
 ﻿@{
 RootModule = 'PSModule.psm1'
-ModuleVersion = '1.1.0.0'
+ModuleVersion = '1.1.1.0'
 GUID = '1d73a601-4a6c-43c5-ba3f-619b18bbb404'
 Author = 'Microsoft Corporation'
 CompanyName = 'Microsoft Corporation'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ branches:
 test_script:
     - SET PATH=c:\Program Files\WindowsPowerShell\Modules\;%PATH%;
     - ps: |
-        $ModuleVersion = '1.1.0.0'
+        $ModuleVersion = '1.1.1.0'
         $InstallLocation = "$Env:ProgramFiles\WindowsPowerShell\Modules\PowerShellGet"
         if($PSVersionTable.PSVersion -ge '5.0.0')
         {


### PR DESCRIPTION
Fix for 'Update-Module fails with ModuleAuthenticodeSignature error for modules with signed PSD1' #8
Also includes fix for 'Properties of AdditionalMetadata are case-sensitive'  #7
Changed the ErrorAction to Ignore for few cmdlet usages as they should not show up in ErrorVaraible. For example, error returned by 'Get-Command Test-FileCatalog' should be ignored.
