### PR TITLE
Enabling CI for Mac, Linux and PSCore on Windows

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+Contributing to PowerShellGet
+=============================
+
+Please refer to [the common contribution guidelines in PowerShell git organization](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md) 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,47 @@
+<!--- Provide a general summary of the issue in the Title above -->
+
+<!--
+- Search the existing issues.
+- Fill out the following template
+- If it is a bug report, make sure you are able to repro it with latest PowerShellGet module from master branch.
+-->
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include at least the output from $PSVersionTable -->
+
+```PowerShell
+
+> $PSVersionTable
+
+> Get-Module
+
+> Get-Module -ListAvailable PowerShellGet,PackageManagement
+
+> Get-PackageProvider
+
+> Get-PackageProvider -ListAvailable
+```

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 
+language: cpp
+
 git:
   depth: 1000
 
@@ -33,3 +35,13 @@ install:
 
 script: 
   - ./tools/travis.sh
+
+
+
+
+
+
+
+
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+
+git:
+  depth: 1000
+
+os:
+  - linux
+  - osx
+sudo: required
+dist: trusty
+osx_image: xcode7.3
+
+matrix:
+  allow_failures:
+    - os: osx
+  fast_finish: true
+
+
+addons:
+  artifacts:
+    paths: $(ls ./../PowerShellGet.zip | tr "\n" ":")
+
+
+install:
+  - export PATH=~/.dotnet:$PATH
+  - pushd tools
+  - chmod +x download.sh
+  - chmod +x travis.sh
+  - ./download.sh
+  - popd
+  # Default 2.0.0 Ruby is buggy
+  # Default bundler version is buggy
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm use 2.2.1; gem uninstall bundler -v1.13.1; fi
+
+script: 
+  - ./tools/travis.sh
+
+
+
+
+
+
+
+
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,3 @@ install:
 
 script: 
   - ./tools/travis.sh
-
-
-
-
-
-
-
-
-
-

--- a/PowerShellGet/PSGet.Resource.psd1
+++ b/PowerShellGet/PSGet.Resource.psd1
@@ -220,7 +220,7 @@ ConvertFrom-StringData @'
         InvalidModuleAuthenticodeSignature=The module '{0}' cannot be installed or updated because the authenticode signature of the file '{1}' is not valid.
         InvalidCatalogSignature=The module '{0}' cannot be installed because the catalog signature in '{1}' does not match the hash generated from the module.
         AuthenticodeIssuerMismatch=Authenticode issuer '{0}' of the new module '{1}' with version '{2}' is not matching with the authenticode issuer '{3}' of the previously-installed module '{4}' with version '{5}'. If you still want to install or update, use -SkipPublisherCheck parameter.
-        ModuleCommandAlreadyAvailable=A command with name '{0}' is already available on this system. This module '{1}' may override the existing commands. If you still want to install this module '{1}', use -AllowClobber parameter.
+        ModuleCommandAlreadyAvailable=The following commands are already available on this system:'{0}'. This module '{1}' may override the existing commands. If you still want to install this module '{1}', use -AllowClobber parameter.
         CatalogFileFound=Found the catalog file '{0}' in the module '{1}' contents.        
         CatalogFileNotFoundInAvailableModule=Catalog file '{0}' is not found in the contents of the previously-installed module '{1}' with the same name.
         CatalogFileNotFoundInNewModule=Catalog file '{0}' is not found in the contents of the module '{1}' being installed.

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -6141,7 +6141,7 @@ function Check-PSGalleryApiAvailability
     # check internet availability first
     $connected = $false
     $microsoftDomain = 'www.microsoft.com'
-    if(Get-Command Microsoft.PowerShell.Management\Test-Connection -ErrorAction Ignore)
+    if((-not $script:IsCoreCLR) -and (Get-Command Microsoft.PowerShell.Management\Test-Connection -ErrorAction Ignore))
     {        
         $connected = Microsoft.PowerShell.Management\Test-Connection -ComputerName $microsoftDomain -Count 1 -Quiet
     }

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -2633,7 +2633,7 @@ function Publish-Script
             $message = $LocalizedData.PublishPSArtifactUnsupportedOnNano -f "Script"
             ThrowError -ExceptionName "System.InvalidOperationException" `
                         -ExceptionMessage $message `
-                        -ErrorId 'PublishScriptIsNotSupportedOnPowerShellCoreEdition `
+                        -ErrorId 'PublishScriptIsNotSupportedOnPowerShellCoreEdition' `
                         -CallerPSCmdlet $PSCmdlet `
                         -ExceptionObject $PSCmdlet `
                         -ErrorCategory InvalidOperation

--- a/PowerShellGet/PowerShellGet.psd1
+++ b/PowerShellGet/PowerShellGet.psd1
@@ -41,7 +41,7 @@ AliasesToExport = @('inmo',
 FileList = @('PSModule.psm1',
              'PSGet.Format.ps1xml',
              'PSGet.Resource.psd1')
-RequiredModules = @(@{ModuleName='PackageManagement';ModuleVersion='1.1.0.0'})
+RequiredModules = @(@{ModuleName='PackageManagement';ModuleVersion='1.0.0.1'})
 PrivateData = @{
                 "PackageManagementProviders" = 'PSModule.psm1'
                 "SupportedPowerShellGetFormatVersions" = @('1.x')

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/91p7lpjoxit3gw72/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/powershellget/branch/master)
 
 [![Join the chat at https://gitter.im/PowerShell/PowerShellGet](https://badges.gitter.im/PowerShell/PowerShellGet.svg)](https://gitter.im/PowerShell/PowerShellGet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -8,6 +7,31 @@ Introduction
 PowerShellGet is a PowerShell module with commands for discovering, installing, updating and publishing the PowerShell artifacts like Modules, DSC Resources, Role Capabilities and Scripts.
 
 PowerShellGet module is also integrated with the PackageManagement module as a provider, users can also use the PackageManagement cmdlets for discovering, installing and updating the PowerShell artifacts like Modules and Scripts.
+
+
+Build status
+============
+### development branch
+
+| AppVeyor (Windows - PS & PSCore)| Travis CI (Linux / macOS)    |
+|---------------------------------|------------------------------|
+| [![d-av-image][]][d-av-site]    | [![d-tv-image][]][d-tv-site] |
+
+### master branch
+
+| AppVeyor (Windows - PS & PSCore)| Travis CI (Linux / macOS)    |
+|---------------------------------|------------------------------|
+| [![m-av-image][]][m-av-site]    | [![m-tv-image][]][m-tv-site] |
+
+[d-av-image]: https://ci.appveyor.com/api/projects/status/91p7lpjoxit3gw72/branch/development?svg=true
+[d-av-site]: https://ci.appveyor.com/project/PowerShell/powershellget/branch/development
+[d-tv-image]: https://travis-ci.org/PowerShell/PowerShellGet.svg?branch=development
+[d-tv-site]: https://travis-ci.org/PowerShell/PowerShellGet/branches
+
+[m-av-image]: https://ci.appveyor.com/api/projects/status/91p7lpjoxit3gw72/branch/master?svg=true
+[m-av-site]: https://ci.appveyor.com/project/PowerShell/powershellget/branch/master
+[m-tv-image]: https://travis-ci.org/PowerShell/PowerShellGet.svg?branch=master
+[m-tv-site]: https://travis-ci.org/PowerShell/PowerShellGet/branches
 
 Documentation
 =============

--- a/Tests/PSGetFindModule.Tests.ps1
+++ b/Tests/PSGetFindModule.Tests.ps1
@@ -21,8 +21,8 @@ function SuiteSetup {
     Import-Module "$PSScriptRoot\PSGetTestUtils.psm1" -WarningAction SilentlyContinue
     Import-Module "$PSScriptRoot\Asserts.psm1" -WarningAction SilentlyContinue
 
-    $script:MyDocumentsModulesPath = Join-Path -Path ([Environment]::GetFolderPath("MyDocuments")) -ChildPath "WindowsPowerShell\Modules"
-    $script:PSGetLocalAppDataPath="$env:LOCALAPPDATA\Microsoft\Windows\PowerShell\PowerShellGet"
+    $script:MyDocumentsModulesPath = Get-CurrentUserModulesPath
+    $script:PSGetLocalAppDataPath = Get-PSGetLocalAppDataPath
     $script:DscTestModule = "DscTestModule"
 
     #Bootstrap NuGet binaries
@@ -557,5 +557,6 @@ Describe PowerShell.PSGet.FindModuleTests.P2 -Tags 'P2', 'OuterLoop' {
                 AssertFullyQualifiedErrorIdEquals -Scriptblock $scriptBlock -ExpectedFullyQualifiedErrorId $inputParameters.FullyQualifiedErrorId
             }
         }
-    }
+    } `
+    -Skip:$($PSEdition -eq 'Core') 
 }

--- a/Tests/PSGetFindScript.Tests.ps1
+++ b/Tests/PSGetFindScript.Tests.ps1
@@ -18,8 +18,7 @@ function SuiteSetup {
     Import-Module "$PSScriptRoot\PSGetTestUtils.psm1" -WarningAction SilentlyContinue
     Import-Module "$PSScriptRoot\Asserts.psm1" -WarningAction SilentlyContinue
     
-    $script:MyDocumentsScriptsPath = Join-Path -Path ([Environment]::GetFolderPath("MyDocuments")) -ChildPath "WindowsPowerShell\Scripts"
-    $script:PSGetLocalAppDataPath="$env:LOCALAPPDATA\Microsoft\Windows\PowerShell\PowerShellGet"
+    $script:PSGetLocalAppDataPath = Get-PSGetLocalAppDataPath
     $script:DscTestScript = "DscTestScript"
 
     #Bootstrap NuGet binaries

--- a/Tests/PSGetInstallModule.Tests.ps1
+++ b/Tests/PSGetInstallModule.Tests.ps1
@@ -456,7 +456,7 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
     It "InstallModuleNeedsCurrentUserScopeParameterForNonAdminUser" {
         $NonAdminConsoleOutput = Join-Path $TestDrive 'nonadminconsole-out.txt'
 
-        Start-Process "$PSHOME\PowerShell.exe" -ArgumentList '$null = Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;
+        Start-Process "$PSHOME\PowerShell.exe" -ArgumentList '$null = Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Scope CurrentUser;
                                                               $null = Import-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;
                                                               Install-Module -Name ContosoServer' `
                                                -Credential $script:credential `

--- a/Tests/PSGetInstallModule.Tests.ps1
+++ b/Tests/PSGetInstallModule.Tests.ps1
@@ -22,7 +22,7 @@ function SuiteSetup {
     $script:MyDocumentsModulesPath = Get-CurrentUserModulesPath
     $script:PSGetLocalAppDataPath = Get-PSGetLocalAppDataPath
     $script:TempPath = Get-TempPath
-    New-Item -Path $script:MyDocumentsModulesPath -ItemType Directory -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+    $null = New-Item -Path $script:MyDocumentsModulesPath -ItemType Directory -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
     #Bootstrap NuGet binaries
     Install-NuGetBinaries
 
@@ -477,6 +477,7 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
         ($whoamiValue -eq "NT AUTHORITY\SYSTEM") -or
         ($whoamiValue -eq "NT AUTHORITY\LOCAL SERVICE") -or
         ($whoamiValue -eq "NT AUTHORITY\NETWORK SERVICE") -or
+        ($env:APPVEYOR_TEST_PASS -eq 'True') -or
         ($PSEdition -eq 'Core') -or
         ($PSVersionTable.PSVersion -lt '4.0.0')
     )
@@ -509,6 +510,7 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
         ($whoamiValue -eq "NT AUTHORITY\SYSTEM") -or
         ($whoamiValue -eq "NT AUTHORITY\LOCAL SERVICE") -or
         ($whoamiValue -eq "NT AUTHORITY\NETWORK SERVICE") -or
+        ($PSEdition -eq 'Core') -or
         ($PSCulture -ne 'en-US') -or
         ($PSVersionTable.PSVersion -lt '5.0.0')
     )

--- a/Tests/PSGetInstallModule.Tests.ps1
+++ b/Tests/PSGetInstallModule.Tests.ps1
@@ -474,11 +474,11 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
     -Skip:$(
         $whoamiValue = (whoami)
 
+        ($PSEdition -eq 'Core') -or
         ($whoamiValue -eq "NT AUTHORITY\SYSTEM") -or
         ($whoamiValue -eq "NT AUTHORITY\LOCAL SERVICE") -or
         ($whoamiValue -eq "NT AUTHORITY\NETWORK SERVICE") -or
         ($env:APPVEYOR_TEST_PASS -eq 'True') -or
-        ($PSEdition -eq 'Core') -or
         ($PSVersionTable.PSVersion -lt '4.0.0')
     )
 
@@ -507,10 +507,10 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
     -Skip:$(
         $whoamiValue = (whoami)
 
+        ($PSEdition -eq 'Core') -or
         ($whoamiValue -eq "NT AUTHORITY\SYSTEM") -or
         ($whoamiValue -eq "NT AUTHORITY\LOCAL SERVICE") -or
         ($whoamiValue -eq "NT AUTHORITY\NETWORK SERVICE") -or
-        ($PSEdition -eq 'Core') -or
         ($PSCulture -ne 'en-US') -or
         ($PSVersionTable.PSVersion -lt '5.0.0')
     )
@@ -552,7 +552,7 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
         $mod = Get-Module ContosoServer -ListAvailable
         Assert (-not $mod) "Install-Module should not install the module with -WhatIf option"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
 
     # Purpose: InstallModuleWithConfirmAndNoToPrompt
     #
@@ -595,7 +595,7 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
         $res = Get-Module ContosoServer -ListAvailable
         AssertNull $res "Install-Module should not install a module if Confirm is not accepted"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
 
     # Purpose: InstallModuleWithConfirmAndYesToPrompt
     #
@@ -638,7 +638,7 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
         $res = Get-Module ContosoServer -ListAvailable
         Assert (($res.Count -eq 1) -and ($res.Name -eq "ContosoServer")) "Install-Module should install a module if Confirm is accepted"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
 
     # Purpose: Validate PowerShellGet related properties on PSModuleInfo
     #

--- a/Tests/PSGetInstallModule.Tests.ps1
+++ b/Tests/PSGetInstallModule.Tests.ps1
@@ -18,11 +18,11 @@ function SuiteSetup {
     Import-Module "$PSScriptRoot\PSGetTestUtils.psm1" -WarningAction SilentlyContinue
     Import-Module "$PSScriptRoot\Asserts.psm1" -WarningAction SilentlyContinue
     
-    $script:MyDocumentsModulesPath = Join-Path -Path ([Environment]::GetFolderPath("MyDocuments")) -ChildPath "WindowsPowerShell\Modules"
+    $script:ProgramFilesModulesPath = Get-AllUsersModulesPath
+    $script:MyDocumentsModulesPath = Get-CurrentUserModulesPath
+    $script:PSGetLocalAppDataPath = Get-PSGetLocalAppDataPath
+    $script:TempPath = Get-TempPath
     New-Item -Path $script:MyDocumentsModulesPath -ItemType Directory -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
-    $script:ProgramFilesModulesPath = Microsoft.PowerShell.Management\Join-Path -Path $env:ProgramFiles -ChildPath "WindowsPowerShell\Modules"
-    $script:PSGetLocalAppDataPath="$env:LOCALAPPDATA\Microsoft\Windows\PowerShell\PowerShellGet"
-
     #Bootstrap NuGet binaries
     Install-NuGetBinaries
 
@@ -42,11 +42,15 @@ function SuiteSetup {
     PSGetTestUtils\Uninstall-Module ContosoServer
     PSGetTestUtils\Uninstall-Module ContosoClient
 
-    $script:userName = "PSGetUser"
-    $password = "Password1"
-    $null = net user $script:userName $password /add
-    $secstr = ConvertTo-SecureString $password -AsPlainText -Force
-    $script:credential = new-object -typename System.Management.Automation.PSCredential -argumentlist $script:userName, $secstr
+    if($PSEdition -ne 'Core')
+    {
+        $script:userName = "PSGetUser"
+        $password = "Password1"
+        $null = net user $script:userName $password /add
+        $secstr = ConvertTo-SecureString $password -AsPlainText -Force
+        $script:credential = new-object -typename System.Management.Automation.PSCredential -argumentlist $script:userName, $secstr
+    }
+
     $script:assertTimeOutms = 20000
     $script:UntrustedRepoSourceLocation = 'https://powershell.myget.org/F/powershellget-test-items/api/v2/'
     $script:UntrustedRepoPublishLocation = 'https://powershell.myget.org/F/powershellget-test-items/api/v2/package'
@@ -65,13 +69,16 @@ function SuiteCleanup {
     # Import the PowerShellGet provider to reload the repositories.
     $null = Import-PackageProvider -Name PowerShellGet -Force
 
-    # Delete the user
-    net user $script:UserName /delete | Out-Null
-    # Delete the user profile
-    $userProfile = (Get-WmiObject -Class Win32_UserProfile | Where-Object {$_.LocalPath -match $script:UserName})
-    if($userProfile)
+    if($PSEdition -ne 'Core')
     {
-	    RemoveItem $userProfile.LocalPath
+        # Delete the user
+        net user $script:UserName /delete | Out-Null
+        # Delete the user profile
+        $userProfile = (Get-WmiObject -Class Win32_UserProfile | Where-Object {$_.LocalPath -match $script:UserName})
+        if($userProfile)
+        {
+            RemoveItem $userProfile.LocalPath
+        }
     }
 }
 
@@ -447,17 +454,6 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: it should fail with an error
     #
     It "InstallModuleNeedsCurrentUserScopeParameterForNonAdminUser" {
-        $whoamiValue = (whoami)
-
-        if( ($whoamiValue -eq "NT AUTHORITY\SYSTEM") -or
-            ($whoamiValue -eq "NT AUTHORITY\LOCAL SERVICE") -or
-            ($whoamiValue -eq "NT AUTHORITY\NETWORK SERVICE") -or
-            ($PSVersionTable.PSVersion -lt [Version]"4.0") )
-        {            
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion) for user $whoamiValue"
-            return
-        }
-
         $NonAdminConsoleOutput = Join-Path $TestDrive 'nonadminconsole-out.txt'
 
         Start-Process "$PSHOME\PowerShell.exe" -ArgumentList '$null = Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;
@@ -474,7 +470,16 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
         Assert ($content -match "InstallModuleNeedsCurrentUserScopeParameter") "Install module without currentuser scope on non-admin user console should fail, $content"
         $mod = Get-Module ContosoServer -ListAvailable
         Assert (-not $mod) "Install module without currentuser scope on non-admin user console should not install"
-    }
+    } `
+    -Skip:$(
+        $whoamiValue = (whoami)
+
+        ($whoamiValue -eq "NT AUTHORITY\SYSTEM") -or
+        ($whoamiValue -eq "NT AUTHORITY\LOCAL SERVICE") -or
+        ($whoamiValue -eq "NT AUTHORITY\NETWORK SERVICE") -or
+        ($PSEdition -eq 'Core') -or
+        ($PSVersionTable.PSVersion -lt '4.0.0')
+    )
 
     # Purpose: ValidateModuleIsInUseError
     #
@@ -483,19 +488,6 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: should fail with an error
     #
     It "ValidateModuleIsInUseError" {
-        
-        $whoamiValue = (whoami)
-
-        if( ($whoamiValue -eq "NT AUTHORITY\SYSTEM") -or
-            ($whoamiValue -eq "NT AUTHORITY\LOCAL SERVICE") -or
-            ($whoamiValue -eq "NT AUTHORITY\NETWORK SERVICE") -or
-            ($PSVersionTable.PSVersion -lt '5.0.0') -or
-            ($PSCulture -ne 'en-US') )
-        {            
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion) for user $whoamiValue"
-            return
-        }
-
         $NonAdminConsoleOutput = Join-Path $TestDrive 'nonadminconsole-out.txt'
         Start-Process "$PSHOME\PowerShell.exe" -ArgumentList '$null = Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Scope CurrentUser;
                                                               $null = Import-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;
@@ -510,7 +502,16 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
         
         Assert ($content -and ($content -match 'DscTestModule')) "Install-module with -force should fail when a module version being installed is in use, $content."
         RemoveItem $NonAdminConsoleOutput
-    }
+    } `
+    -Skip:$(
+        $whoamiValue = (whoami)
+
+        ($whoamiValue -eq "NT AUTHORITY\SYSTEM") -or
+        ($whoamiValue -eq "NT AUTHORITY\LOCAL SERVICE") -or
+        ($whoamiValue -eq "NT AUTHORITY\NETWORK SERVICE") -or
+        ($PSCulture -ne 'en-US') -or
+        ($PSVersionTable.PSVersion -lt '5.0.0')
+    )
 
     # Purpose: InstallModuleWithWhatIf
     #
@@ -519,13 +520,7 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: it should not install the module
     #
     It "InstallModuleWithWhatIf" {
-        if(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
-        {            
-            Write-Warning -Message "Skipped on OSVersion: $([System.Environment]::OSVersion.Version) with PSCulture: $PSCulture"
-            return
-        }
-
-        $outputPath = $env:temp
+        $outputPath = $script:TempPath
         $guid =  [system.guid]::newguid().tostring()
         $outputFilePath = Join-Path $outputPath "$guid"
         $runspace = CreateRunSpace $outputFilePath 1
@@ -554,7 +549,8 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
 
         $mod = Get-Module ContosoServer -ListAvailable
         Assert (-not $mod) "Install-Module should not install the module with -WhatIf option"
-    }
+    } `
+    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
 
     # Purpose: InstallModuleWithConfirmAndNoToPrompt
     #
@@ -563,14 +559,7 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: module should not be installed after confirming NO
     #
     It "InstallModuleWithConfirmAndNoToPrompt" {
-
-        if(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
-        {            
-            Write-Warning -Message "Skipped on OSVersion: $([System.Environment]::OSVersion.Version) with PSCulture: $PSCulture"
-            return
-        }
-
-        $outputPath = $env:temp
+        $outputPath = $script:TempPath
         $guid =  [system.guid]::newguid().tostring()
         $outputFilePath = Join-Path $outputPath "$guid"
         $runspace = CreateRunSpace $outputFilePath 1
@@ -603,7 +592,8 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
 
         $res = Get-Module ContosoServer -ListAvailable
         AssertNull $res "Install-Module should not install a module if Confirm is not accepted"
-    }
+    } `
+    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
 
     # Purpose: InstallModuleWithConfirmAndYesToPrompt
     #
@@ -612,13 +602,7 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: module should be installed after confirming YES
     #
     It "InstallModuleWithConfirmAndYesToPrompt" {
-        if(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
-        {            
-            Write-Warning -Message "Skipped on OSVersion: $([System.Environment]::OSVersion.Version) with PSCulture: $PSCulture"
-            return
-        }
-
-        $outputPath = $env:temp
+        $outputPath = $script:TempPath
         $guid =  [system.guid]::newguid().tostring()
         $outputFilePath = Join-Path $outputPath "$guid"
         $runspace = CreateRunSpace $outputFilePath 1
@@ -651,7 +635,8 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
 
         $res = Get-Module ContosoServer -ListAvailable
         Assert (($res.Count -eq 1) -and ($res.Name -eq "ContosoServer")) "Install-Module should install a module if Confirm is accepted"
-    }
+    } `
+    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
 
     # Purpose: Validate PowerShellGet related properties on PSModuleInfo
     #
@@ -660,12 +645,6 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: PSModuleInfo should have Tags, LicenseUri, ProjectUri, IconUri, ReleaseNotes, SourceName, SourceLocation, DateUpdated properties
     #
     It ValidatePSGetPropertiesOnPSModuleInfoFromGetModule {
-        if($PSVersionTable.PSVersion -lt '5.0.0')
-        {            
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion)"
-            return
-        }
-
         Install-Module ContosoServer -Repository PSGallery
         $res = Get-Module ContosoServer -ListAvailable
         Assert (($res.Count -eq 1) -and ($res.Name -eq "ContosoServer") -and ($res.Version -ge [Version]"2.5")) "Install-Module failed to install ContosoServer"
@@ -675,7 +654,7 @@ Describe PowerShell.PSGet.InstallModuleTests -Tags 'BVT','InnerLoop' {
         AssertNotNull $res.IconUri "IconUri value is missing on PSModuleInfo"
         AssertNotNull $res.ReleaseNotes "ReleaseNotes value is missing on PSModuleInfo"
         AssertNotNull $res.RepositorySourceLocation "RepositorySourceLocation value is missing on PSModuleInfo"
-    }
+    } -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
     # Purpose: Install a module with Find-RoleCapability output
     #
@@ -912,12 +891,6 @@ Describe PowerShell.PSGet.InstallModuleTests.P1 -Tags 'P1','OuterLoop' {
     # Expected Result: PSModuleInfo should have Tags, LicenseUri, ProjectUri, IconUri, ReleaseNotes, SourceName, SourceLocation, DateUpdated properties
     #
     It ValidatePSGetPropertiesOnPSModuleInfoFromImportModule {
-        
-        if($PSVersionTable.PSVersion -lt '5.0.0') {
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion)"
-            return
-        }
-
         Install-Module ContosoServer -Repository PSGallery
         $res = Import-Module ContosoServer -PassThru -Force
         $res | Remove-Module -Force
@@ -928,7 +901,7 @@ Describe PowerShell.PSGet.InstallModuleTests.P1 -Tags 'P1','OuterLoop' {
         AssertNotNull $res.IconUri "IconUri value is missing on PSModuleInfo"
         AssertNotNull $res.ReleaseNotes "ReleaseNotes value is missing on PSModuleInfo"
         AssertNotNull $res.RepositorySourceLocation "RepositorySourceLocation value is missing on PSModuleInfo"
-    }
+    } -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
     # Purpose: Install a modul from an untrusted repository and press No to the prompt
     #
@@ -937,25 +910,18 @@ Describe PowerShell.PSGet.InstallModuleTests.P1 -Tags 'P1','OuterLoop' {
     # Expected Result: module should not be installed
     #
     It InstallAModulFromUntrustedRepositoryAndNoToPrompt {
-
-        if(($PSCulture -ne 'en-US') -or ($PSVersionTable.PSVersion -lt '4.0.0'))
-        {
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion) and PSCulture: $PSCulture"
-            return
-        }
-
         try {
             #Register an untrusted test repository
             Register-PSRepository -Name UntrustedTestRepo -SourceLocation $script:UntrustedRepoSourceLocation -PublishLocation $script:UntrustedRepoPublishLocation
             $moduleRepo = Get-PSRepository -Name UntrustedTestRepo
             AssertEqualsCaseInsensitive $moduleRepo.SourceLocation $script:UntrustedRepoSourceLocation "Test repository 'UntrustedTestRepo' is not registered properly"
 
-            $outputPath = $env:temp
+            $outputPath = $script:TempPath
             $guid =  [system.guid]::newguid().tostring()
             $outputFilePath = Join-Path $outputPath "$guid"
             $runspace = CreateRunSpace $outputFilePath 1
 
-            if($PSVersionTable.PSVersion -ge [Version]"4.0")
+            if($PSVersionTable.PSVersion -ge '4.0.0')
             {
                 # 2 is mapped to NO in ShouldProcess prompt
                 $Global:proxy.UI.ChoiceToMake=2
@@ -993,7 +959,7 @@ Describe PowerShell.PSGet.InstallModuleTests.P1 -Tags 'P1','OuterLoop' {
         finally {
             Get-PSRepository -Name UntrustedTestRepo -ErrorAction SilentlyContinue | Unregister-PSRepository -ErrorAction SilentlyContinue
         }
-    }
+    } -Skip:$(($PSCulture -ne 'en-US') -or ($PSVersionTable.PSVersion -lt '4.0.0') -or ($PSEdition -eq 'Core'))
 
     # Purpose: Install a modul from an untrusted repository and press YES to the prompt
     #
@@ -1002,19 +968,13 @@ Describe PowerShell.PSGet.InstallModuleTests.P1 -Tags 'P1','OuterLoop' {
     # Expected Result: module should be installed
     #
     It InstallAModulFromUntrustedRepositoryAndYesToPrompt {
-        if(($PSCulture -ne 'en-US') -or ($PSVersionTable.PSVersion -lt '4.0.0'))
-        {
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion) and PSCulture: $PSCulture"
-            return
-        }
-
         try {
             #Register an untrusted test repository
             Register-PSRepository -Name UntrustedTestRepo -SourceLocation $script:UntrustedRepoSourceLocation -PublishLocation $script:UntrustedRepoPublishLocation
             $moduleRepo = Get-PSRepository -Name UntrustedTestRepo
             AssertEqualsCaseInsensitive $moduleRepo.SourceLocation $script:UntrustedRepoSourceLocation "Test repository 'UntrustedTestRepo' is not registered properly"
 
-            $outputPath = $env:temp
+            $outputPath = $script:TempPath
             $guid =  [system.guid]::newguid().tostring()
             $outputFilePath = Join-Path $outputPath "$guid"
             $runspace = CreateRunSpace $outputFilePath 1
@@ -1048,7 +1008,7 @@ Describe PowerShell.PSGet.InstallModuleTests.P1 -Tags 'P1','OuterLoop' {
         finally {
             Get-PSRepository -Name UntrustedTestRepo -ErrorAction SilentlyContinue | Unregister-PSRepository -ErrorAction SilentlyContinue
         }
-    }
+    } -Skip:$(($PSCulture -ne 'en-US') -or ($PSVersionTable.PSVersion -lt '4.0.0') -or ($PSEdition -eq 'Core'))
 
     # Get-InstalledModule error cases
     It ValidateGetInstalledModuleWithMultiNamesAndRequiredVersion {
@@ -1225,7 +1185,7 @@ Describe PowerShell.PSGet.InstallModuleTests.P1 -Tags 'P1','OuterLoop' {
             AssertEquals $res1.Repository $RepositoryName "PSGetItemInfo object was created with wrong repository name"
 
             $expectedInstalledLocation = Join-Path $script:ProgramFilesModulesPath -ChildPath $res1.Name
-            if($PSVersionTable.PSVersion -ge [Version]"5.0")
+            if($PSVersionTable.PSVersion -ge '5.0.0')
             {
                 $expectedInstalledLocation = Join-Path -Path $expectedInstalledLocation -ChildPath $res1.Version
             }
@@ -1310,7 +1270,7 @@ Describe PowerShell.PSGet.InstallModuleTests.P2 -Tags 'P2','OuterLoop' {
             AssertNotNull $DepModuleDetails "$DepencyModuleNames dependencies is not installed properly"
             Assert ($DepModuleDetails.Count -ge $DepencyModuleNames.Count)  "$DepencyModuleNames dependencies is not installed properly"
 
-            if($PSVersionTable.PSVersion -ge [Version]"5.0")
+            if($PSVersionTable.PSVersion -ge '5.0.0')
             {
                 $res2 | ForEach-Object {
                     $mod = Get-InstalledModule -Name $_.Name -MinimumVersion $_.Version

--- a/Tests/PSGetInstallScript.Tests.ps1
+++ b/Tests/PSGetInstallScript.Tests.ps1
@@ -494,7 +494,7 @@ Describe PowerShell.PSGet.InstallScriptTests -Tags 'BVT','InnerLoop' {
     #
     It "InstallScriptNeedsCurrentUserScopeParameterForNonAdminUser" {
         $NonAdminConsoleOutput = Join-Path $TestDrive 'nonadminconsole-out.txt'
-        Start-Process "$PSHOME\PowerShell.exe" -ArgumentList '$null = Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;
+        Start-Process "$PSHOME\PowerShell.exe" -ArgumentList '$null = Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Scope CurrentUser;
                                                               $null = Import-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;
                                                               Install-Script -Name Fabrikam-ServerScript -Scope AllUsers' `
                                                -Credential $script:credential `

--- a/Tests/PSGetInstallScript.Tests.ps1
+++ b/Tests/PSGetInstallScript.Tests.ps1
@@ -515,6 +515,7 @@ Describe PowerShell.PSGet.InstallScriptTests -Tags 'BVT','InnerLoop' {
         ($whoamiValue -eq "NT AUTHORITY\SYSTEM") -or
         ($whoamiValue -eq "NT AUTHORITY\LOCAL SERVICE") -or
         ($whoamiValue -eq "NT AUTHORITY\NETWORK SERVICE") -or
+        ($env:APPVEYOR_TEST_PASS -eq 'True') -or
         ($PSEdition -eq 'Core') -or
         ($PSVersionTable.PSVersion -lt '4.0.0')
     )

--- a/Tests/PSGetInstallScript.Tests.ps1
+++ b/Tests/PSGetInstallScript.Tests.ps1
@@ -669,7 +669,8 @@ Describe PowerShell.PSGet.InstallScriptTests -Tags 'BVT','InnerLoop' {
             Set-PATHVariableForScriptsInstallLocation -Scope CurrentUser
             Get-InstalledScript -Name Fabrikam-ServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
         }
-    }
+    } `
+    -Skip:$($IsWindows -eq $false)
 
     # Purpose: InstallScript_CurrentUser_Force_NoPromptForAddingtoPATHVariable
     #
@@ -709,7 +710,8 @@ Describe PowerShell.PSGet.InstallScriptTests -Tags 'BVT','InnerLoop' {
            
             $script:psgetModuleInfo = Import-Module -Name PowerShellGet -Force -PassThru
         }
-    }
+    } `
+    -Skip:$($IsWindows -eq $false)
 
     # Purpose: InstallScript_CurrentUser_NO_toThePromptForAddingtoPATHVariable
     #
@@ -1262,7 +1264,8 @@ Describe PowerShell.PSGet.InstallScriptTests.P1 -Tags 'P1','OuterLoop' {
 
             Get-InstalledScript -Name Fabrikam-ServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
         }
-    }
+    } `
+    -Skip:$($IsWindows -eq $false)
 
     # Purpose: InstallPackage_Script_AllUsers_Force_NoPromptForAddingtoPATHVariable
     #
@@ -1293,7 +1296,8 @@ Describe PowerShell.PSGet.InstallScriptTests.P1 -Tags 'P1','OuterLoop' {
 
             Get-InstalledScript -Name Fabrikam-ServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
         }
-    }
+    } `
+    -Skip:$($IsWindows -eq $false)
 
     # Purpose: InstallPackage_Script_CurrentUser_NO_toThePromptForAddingtoPATHVariable
     #

--- a/Tests/PSGetInstallScript.Tests.ps1
+++ b/Tests/PSGetInstallScript.Tests.ps1
@@ -434,14 +434,18 @@ Describe PowerShell.PSGet.InstallScriptTests -Tags 'BVT','InnerLoop' {
         Find-Script $scriptName | Install-Script -Scope AllUsers
         $res = Get-InstalledScript $scriptName
         AssertEquals $res.InstalledLocation $script:ProgramFilesScriptsPath "Install-Script with AllUsers scope did not install Fabrikam-ServerScript to program files scripts folder, $script:ProgramFilesScriptsPath"
-        $cmdInfo = Get-Command -Name $scriptName
-        AssertNotNull $cmdInfo "Script installed to the current user scope is not found by the Get-Command cmdlet" 
-        AssertEquals $cmdInfo.Name "$scriptName.ps1" "Script installed to the current user scope is not found by the Get-Command cmdlet, $cmdlInfo" 
-        
-        # CommandInfo.Source is not available on 3.0 and 4.0 downlevel PS versions
-        if($PSVersionTable.PSVersion -ge '5.0.0')
+
+        if($IsWindows -ne $False)
         {
-            AssertEquals $cmdInfo.Source "$($res.InstalledLocation)\$scriptName.ps1" "Script installed to the current user scope is not found by the Get-Command cmdlet, $($cmdlInfo.Source)"
+            $cmdInfo = Get-Command -Name $scriptName
+            AssertNotNull $cmdInfo "Script installed to the current user scope is not found by the Get-Command cmdlet" 
+            AssertEquals $cmdInfo.Name "$scriptName.ps1" "Script installed to the current user scope is not found by the Get-Command cmdlet, $cmdlInfo" 
+            
+            # CommandInfo.Source is not available on 3.0 and 4.0 downlevel PS versions
+            if($PSVersionTable.PSVersion -ge '5.0.0')
+            {
+                AssertEquals $cmdInfo.Source "$($res.InstalledLocation)\$scriptName.ps1" "Script installed to the current user scope is not found by the Get-Command cmdlet, $($cmdlInfo.Source)"
+            }
         }
     }
 
@@ -456,14 +460,17 @@ Describe PowerShell.PSGet.InstallScriptTests -Tags 'BVT','InnerLoop' {
         Install-Script $scriptName -Scope CurrentUser
         $res = Get-InstalledScript $scriptName
         AssertEquals $res.InstalledLocation $script:MyDocumentsScriptsPath "Install-Script with CurrentUser scope did not install Fabrikam-ServerScript to user documents folder, $script:MyDocumentsScriptsPath"
-        $cmdInfo = Get-Command -Name $scriptName
-        AssertNotNull $cmdInfo "Script installed to the current user scope is not found by the Get-Command cmdlet" 
-        AssertEquals $cmdInfo.Name "$scriptName.ps1" "Script installed to the current user scope is not found by the Get-Command cmdlet, $cmdlInfo" 
-
-        # CommandInfo.Source is not available on 3.0 and 4.0 downlevel PS versions
-        if($PSVersionTable.PSVersion -ge '5.0.0')
+        if($IsWindows -ne $False)
         {
-            AssertEquals $cmdInfo.Source "$($res.InstalledLocation)\$scriptName.ps1" "Script installed to the current user scope is not found by the Get-Command cmdlet, $($cmdlInfo.Source)"
+            $cmdInfo = Get-Command -Name $scriptName
+            AssertNotNull $cmdInfo "Script installed to the current user scope is not found by the Get-Command cmdlet" 
+            AssertEquals $cmdInfo.Name "$scriptName.ps1" "Script installed to the current user scope is not found by the Get-Command cmdlet, $cmdlInfo" 
+
+            # CommandInfo.Source is not available on 3.0 and 4.0 downlevel PS versions
+            if($PSVersionTable.PSVersion -ge '5.0.0')
+            {
+                AssertEquals $cmdInfo.Source "$($res.InstalledLocation)\$scriptName.ps1" "Script installed to the current user scope is not found by the Get-Command cmdlet, $($cmdlInfo.Source)"
+            }
         }
     }
 
@@ -574,7 +581,7 @@ Describe PowerShell.PSGet.InstallScriptTests -Tags 'BVT','InnerLoop' {
             Get-InstalledScript -Name Fabrikam-ServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
         }
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
 
     # Purpose: InstallScript_AllUsers_YES_toThePromptForAddingtoPATHVariable
     #
@@ -632,7 +639,7 @@ Describe PowerShell.PSGet.InstallScriptTests -Tags 'BVT','InnerLoop' {
             Get-InstalledScript -Name Fabrikam-ServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
         }
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
 
     # Purpose: InstallScript_CurrentUser_NoPathUpdate_NoPromptForAddingtoPATHVariable
     #
@@ -757,7 +764,7 @@ Describe PowerShell.PSGet.InstallScriptTests -Tags 'BVT','InnerLoop' {
             Get-InstalledScript -Name Fabrikam-ServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
         }
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
 
     # Purpose: InstallScript_CurrentUser_YES_toThePromptForAddingtoPATHVariable
     #
@@ -814,7 +821,7 @@ Describe PowerShell.PSGet.InstallScriptTests -Tags 'BVT','InnerLoop' {
             Get-InstalledScript -Name Fabrikam-ServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
         }
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
 
     # Purpose: InstallScriptWithWhatIf
     #
@@ -853,7 +860,7 @@ Describe PowerShell.PSGet.InstallScriptTests -Tags 'BVT','InnerLoop' {
         $res = Get-InstalledScript Fabrikam-ServerScript -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
         Assert (-not $res) "Install-Script should not install the script with -WhatIf option"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
 
     # Purpose: InstallScriptWithConfirmAndNoToPrompt
     #
@@ -896,7 +903,7 @@ Describe PowerShell.PSGet.InstallScriptTests -Tags 'BVT','InnerLoop' {
         $res = Get-InstalledScript Fabrikam-ServerScript -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
         AssertNull $res "Install-Script should not install a script if Confirm is not accepted"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
 
     # Purpose: InstallScriptWithConfirmAndYesToPrompt
     #
@@ -939,7 +946,7 @@ Describe PowerShell.PSGet.InstallScriptTests -Tags 'BVT','InnerLoop' {
         $res = Get-InstalledScript Fabrikam-ServerScript
         AssertEquals $res.Name 'Fabrikam-ServerScript' "Install-Script should install a script if Confirm is accepted, $res"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
 
     <#
     Purpose: Validate the Get-InstalledScript
@@ -1163,7 +1170,7 @@ Describe PowerShell.PSGet.InstallScriptTests.P1 -Tags 'P1','OuterLoop' {
             Get-InstalledScript -Name Fabrikam-ServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
         }
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
 
     # Purpose: InstallPackage_Script_AllUsers_YES_toThePromptForAddingtoPATHVariable
     #
@@ -1223,7 +1230,7 @@ Describe PowerShell.PSGet.InstallScriptTests.P1 -Tags 'P1','OuterLoop' {
             Get-InstalledScript -Name Fabrikam-ServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
         }
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
 
     # Purpose: InstallPackage_Script_AllUsers_NoPathUpdate_NoPromptForAddingtoPATHVariable
     #
@@ -1342,7 +1349,7 @@ Describe PowerShell.PSGet.InstallScriptTests.P1 -Tags 'P1','OuterLoop' {
             Get-InstalledScript -Name Fabrikam-ServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
         }
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
 
     # Purpose: InstallPackage_Script_CurrentUser_YES_toThePromptForAddingtoPATHVariable
     #
@@ -1400,7 +1407,7 @@ Describe PowerShell.PSGet.InstallScriptTests.P1 -Tags 'P1','OuterLoop' {
             Get-InstalledScript -Name Fabrikam-ServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
         }
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
 
     # Purpose: Install a script from an untrusted repository and press No to the prompt
     #

--- a/Tests/PSGetModuleSource.Tests.ps1
+++ b/Tests/PSGetModuleSource.Tests.ps1
@@ -64,7 +64,7 @@ function SuiteSetup {
     AssertEquals $modSource.SourceLocation $script:TestModuleSourceUri "Test module source is not set properly"
 
     # Create a temp folder
-    $script:TempModulesPath="$env:LocalAppData\temp\PSGet_$(Get-Random)"
+    $script:TempModulesPath= Join-Path $script:TempPath "PSGet_$(Get-Random)"
     $null = New-Item -Path $script:TempModulesPath -ItemType Directory -Force
 }
 
@@ -404,7 +404,7 @@ Describe PowerShell.PSGet.ModuleSourceTests.P1 -Tags 'P1','OuterLoop' {
     It RegisterPSRepositoryWithInvalidSMBShareSourceLocation {
 
         $Name='MyTestModSource'
-        $Location="$script:TempPath\DirNotAvailable"
+        $Location = Join-Path $script:TempPath 'DirNotAvailable'
         AssertFullyQualifiedErrorIdEquals -scriptblock {Register-PSRepository -Name $Name -SourceLocation $Location} `
                                           -expectedFullyQualifiedErrorId "PathNotFound,Register-PSRepository"
     }
@@ -420,7 +420,7 @@ Describe PowerShell.PSGet.ModuleSourceTests.P1 -Tags 'P1','OuterLoop' {
 
         $Name='MyTestModSource'
         $Location=$script:TempModulesPath
-        $PublishLocation="$script:TempPath\DirNotAvailable"
+        $PublishLocation = Join-Path $script:TempPath 'DirNotAvailable'
         AssertFullyQualifiedErrorIdEquals -scriptblock {Register-PSRepository -Name $Name -SourceLocation $Location -PublishLocation $PublishLocation} `
                                           -expectedFullyQualifiedErrorId "PathNotFound,Add-PackageSource,Microsoft.PowerShell.PackageManagement.Cmdlets.RegisterPackageSource"
     }
@@ -436,7 +436,7 @@ Describe PowerShell.PSGet.ModuleSourceTests.P1 -Tags 'P1','OuterLoop' {
 
         $Name='MyTestModSource'
         $Location=$script:TempModulesPath
-        $Location2="$script:TempPath\DirNotAvailable"
+        $Location2 = Join-Path $script:TempPath 'DirNotAvailable'
         try
         {
             Register-PSRepository -Name $Name -SourceLocation $Location
@@ -460,7 +460,7 @@ Describe PowerShell.PSGet.ModuleSourceTests.P1 -Tags 'P1','OuterLoop' {
 
         $Name='MyTestModSource'
         $Location=$script:TempModulesPath
-        $Location2="$script:TempPath\DirNotAvailable"
+        $Location2 = Join-Path $script:TempPath 'DirNotAvailable'
         try
         {
             Register-PSRepository -Name $Name -SourceLocation $Location -PublishLocation $Location

--- a/Tests/PSGetModuleSource.Tests.ps1
+++ b/Tests/PSGetModuleSource.Tests.ps1
@@ -19,9 +19,10 @@ function SuiteSetup {
     Import-Module "$PSScriptRoot\PSGetTestUtils.psm1" -WarningAction SilentlyContinue
     Import-Module "$PSScriptRoot\Asserts.psm1" -WarningAction SilentlyContinue
     
-    $script:PSGetLocalAppDataPath="$env:LOCALAPPDATA\Microsoft\Windows\PowerShell\PowerShellGet"
-    $script:ProgramFilesModulesPath = Microsoft.PowerShell.Management\Join-Path -Path $env:ProgramFiles -ChildPath "WindowsPowerShell\Modules"
-    $script:MyDocumentsModulesPath = Microsoft.PowerShell.Management\Join-Path -Path ([Environment]::GetFolderPath("MyDocuments")) -ChildPath "WindowsPowerShell\Modules"
+    $script:ProgramFilesModulesPath = Get-AllUsersModulesPath
+    $script:MyDocumentsModulesPath = Get-CurrentUserModulesPath
+    $script:PSGetLocalAppDataPath = Get-PSGetLocalAppDataPath
+    $script:TempPath = Get-TempPath
     $script:BuiltInModuleSourceName = "PSGallery"
 
     $script:URI200OK = "http://go.microsoft.com/fwlink/?LinkID=533903&clcid=0x409"
@@ -403,7 +404,7 @@ Describe PowerShell.PSGet.ModuleSourceTests.P1 -Tags 'P1','OuterLoop' {
     It RegisterPSRepositoryWithInvalidSMBShareSourceLocation {
 
         $Name='MyTestModSource'
-        $Location="$env:Temp\DirNotAvailable"
+        $Location="$script:TempPath\DirNotAvailable"
         AssertFullyQualifiedErrorIdEquals -scriptblock {Register-PSRepository -Name $Name -SourceLocation $Location} `
                                           -expectedFullyQualifiedErrorId "PathNotFound,Register-PSRepository"
     }
@@ -419,7 +420,7 @@ Describe PowerShell.PSGet.ModuleSourceTests.P1 -Tags 'P1','OuterLoop' {
 
         $Name='MyTestModSource'
         $Location=$script:TempModulesPath
-        $PublishLocation="$env:Temp\DirNotAvailable"
+        $PublishLocation="$script:TempPath\DirNotAvailable"
         AssertFullyQualifiedErrorIdEquals -scriptblock {Register-PSRepository -Name $Name -SourceLocation $Location -PublishLocation $PublishLocation} `
                                           -expectedFullyQualifiedErrorId "PathNotFound,Add-PackageSource,Microsoft.PowerShell.PackageManagement.Cmdlets.RegisterPackageSource"
     }
@@ -435,7 +436,7 @@ Describe PowerShell.PSGet.ModuleSourceTests.P1 -Tags 'P1','OuterLoop' {
 
         $Name='MyTestModSource'
         $Location=$script:TempModulesPath
-        $Location2="$env:Temp\DirNotAvailable"
+        $Location2="$script:TempPath\DirNotAvailable"
         try
         {
             Register-PSRepository -Name $Name -SourceLocation $Location
@@ -459,7 +460,7 @@ Describe PowerShell.PSGet.ModuleSourceTests.P1 -Tags 'P1','OuterLoop' {
 
         $Name='MyTestModSource'
         $Location=$script:TempModulesPath
-        $Location2="$env:Temp\DirNotAvailable"
+        $Location2="$script:TempPath\DirNotAvailable"
         try
         {
             Register-PSRepository -Name $Name -SourceLocation $Location -PublishLocation $Location
@@ -678,7 +679,8 @@ Describe PowerShell.PSGet.ModuleSourceTests.P1 -Tags 'P1','OuterLoop' {
         finally {
             Register-PSRepository -Default -InstallationPolicy Trusted
         }
-    }
+    } `
+    -Skip:$($PSEdition -eq 'Core')
 
     <#
     Purpose: Validate the Unregister-PSRepository functionality with non-registered module source name
@@ -801,7 +803,7 @@ Describe PowerShell.PSGet.ModuleSourceTests.P1 -Tags 'P1','OuterLoop' {
     }
 
     It RegisterPSRepositoryShouldFailWithPSModuleAsPMProviderName {        
-        AssertFullyQualifiedErrorIdEquals -scriptblock {Register-PSRepository -Name Foo -SourceLocation $env:TEMP -PackageManagementProvider PowerShellGet} `
+        AssertFullyQualifiedErrorIdEquals -scriptblock {Register-PSRepository -Name Foo -SourceLocation $script:TempPath -PackageManagementProvider PowerShellGet} `
                                           -expectedFullyQualifiedErrorId "InvalidPackageManagementProviderValue,Register-PSRepository"
     }
 
@@ -811,7 +813,7 @@ Describe PowerShell.PSGet.ModuleSourceTests.P1 -Tags 'P1','OuterLoop' {
     }
 
     It RegisterPackageSourceShouldFailWithPSModuleAsPMProviderName {        
-        AssertFullyQualifiedErrorIdEquals -scriptblock {Register-PackageSource -ProviderName PowerShellGet -Name Foo -Location $env:TEMP -PackageManagementProvider PowerShellGet} `
+        AssertFullyQualifiedErrorIdEquals -scriptblock {Register-PackageSource -ProviderName PowerShellGet -Name Foo -Location $script:TempPath -PackageManagementProvider PowerShellGet} `
                                           -expectedFullyQualifiedErrorId "InvalidPackageManagementProviderValue,Add-PackageSource,Microsoft.PowerShell.PackageManagement.Cmdlets.RegisterPackageSource"
     }
 }

--- a/Tests/PSGetOneGet.Tests.ps1
+++ b/Tests/PSGetOneGet.Tests.ps1
@@ -17,8 +17,8 @@ Describe PowerShell.PSGet.PackageManagementIntegrationTests -Tags 'P1','OuterLoo
         Import-Module "$PSScriptRoot\Asserts.psm1" -WarningAction SilentlyContinue
 
         $script:PSModuleSourcesPath="$env:LOCALAPPDATA\Microsoft\Windows\PowerShell\PowerShellGet"
-        $script:ProgramFilesModulesPath = Microsoft.PowerShell.Management\Join-Path -Path $env:ProgramFiles -ChildPath "WindowsPowerShell\Modules"
-        $script:MyDocumentsModulesPath = Microsoft.PowerShell.Management\Join-Path -Path ([Environment]::GetFolderPath("MyDocuments")) -ChildPath "WindowsPowerShell\Modules"
+        $script:ProgramFilesModulesPath = Get-AllUsersModulesPath
+        $script:MyDocumentsModulesPath = Get-CurrentUserModulesPath
         $script:BuiltInModuleSourceName = "PSGallery"
         $script:PSGetModuleProviderName = 'PowerShellGet'
 

--- a/Tests/PSGetPublishModule.Tests.ps1
+++ b/Tests/PSGetPublishModule.Tests.ps1
@@ -342,7 +342,7 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
         AssertFullyQualifiedErrorIdEquals -scriptblock {Find-Module $script:PublishModuleName -RequiredVersion $version}`
                                           -expectedFullyQualifiedErrorId "NoMatchFoundForCriteria,Microsoft.PowerShell.PackageManagement.Cmdlets.FindPackage"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
 
     # Purpose: PublishModuleWithConfirmAndYesToPrompt
     #
@@ -389,7 +389,7 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
         $psgetItemInfo = Find-Module $script:PublishModuleName -RequiredVersion $version
         Assert (($psgetItemInfo.Name -eq $script:PublishModuleName) -or (($psgetItemInfo.Version.ToString() -eq $version))) "Publish-Module should publish a module with valid module name after confirming YES, $($psgetItemInfo.Name)"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
 
     # Purpose: PublishModuleWithWhatIf
     #
@@ -433,7 +433,7 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
         AssertFullyQualifiedErrorIdEquals -scriptblock {Find-Module $script:PublishModuleName -RequiredVersion $version}`
                                           -expectedFullyQualifiedErrorId "NoMatchFoundForCriteria,Microsoft.PowerShell.PackageManagement.Cmdlets.FindPackage"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
 
     # Purpose: Publish multiple versions of a module
     #
@@ -932,7 +932,7 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
     #
     It PublishModuleWithAsteriskInExportedProperties  {
         $ModuleName = "DscTestModule"
-        $TempModulesPath = "$script:TempPath\$(Get-Random)"
+        $TempModulesPath = Join-Path $script:TempPath "$(Get-Random)"
         $null = New-Item -Path $TempModulesPath -ItemType Directory -Force
     
 
@@ -1161,7 +1161,7 @@ Describe PowerShell.PSGet.PublishModuleTests.P1 -Tags 'P1','OuterLoop' {
             Install-NuGetBinaries
         }
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core') -or ($env:APPVEYOR_TEST_PASS -eq 'True'))
+    -Skip:$(($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core') -or ($env:APPVEYOR_TEST_PASS -eq 'True') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0"))
 	
     It "PublishModuleWithoutNugetExeAndYesToPrompt" {
         try {
@@ -1207,7 +1207,7 @@ Describe PowerShell.PSGet.PublishModuleTests.P1 -Tags 'P1','OuterLoop' {
             Install-NuGetBinaries
         }
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core') -or ($env:APPVEYOR_TEST_PASS -eq 'True'))
+    -Skip:$(($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core') -or ($env:APPVEYOR_TEST_PASS -eq 'True') -or ([System.Environment]::OSVersion.Version -lt "6.2.9200.0"))
 
     # Purpose: PublishNotAvailableModule
     #
@@ -1247,7 +1247,7 @@ Describe PowerShell.PSGet.PublishModuleTests.P1 -Tags 'P1','OuterLoop' {
     # Expected Result: should fail
     #
     It "PublishInvalidModule" {
-        $tempmodulebase = "$script:TempPath\$(Get-Random)\InvalidModule"
+        $tempmodulebase = Join-Path (Join-Path $script:TempPath "$(Get-Random)") "InvalidModule"
         $null = New-Item $tempmodulebase -Force -ItemType Directory        
 
         try
@@ -1283,7 +1283,7 @@ Describe PowerShell.PSGet.PublishModuleTests.P1 -Tags 'P1','OuterLoop' {
     # Expected Result: should fail
     #
     It "PublishInvalidModuleFilePath" {
-        $tempmodulebase = "$script:TempPath\$(Get-Random)\InvalidModule\"
+        $tempmodulebase = Join-Path (Join-Path $script:TempPath "$(Get-Random)") "InvalidModule"
         $null = New-Item $tempmodulebase -Force -ItemType Directory
         $moduleFilePath = Join-Path $tempmodulebase "InvalidModule.psm1"
         Set-Content $moduleFilePath -Value "function foo {'foo'}"

--- a/Tests/PSGetPublishModule.Tests.ps1
+++ b/Tests/PSGetPublishModule.Tests.ps1
@@ -13,12 +13,17 @@
 #>
 
 function SuiteSetup {
+    if($PSEdition -eq 'Core') {
+        return
+    }
+
     Import-Module "$PSScriptRoot\PSGetTestUtils.psm1" -WarningAction SilentlyContinue
     Import-Module "$PSScriptRoot\Asserts.psm1" -WarningAction SilentlyContinue
-    
-    $script:PSGetLocalAppDataPath="$env:LOCALAPPDATA\Microsoft\Windows\PowerShell\PowerShellGet"
-    $script:ProgramFilesModulesPath = Microsoft.PowerShell.Management\Join-Path -Path $env:ProgramFiles -ChildPath "WindowsPowerShell\Modules"
-    $script:MyDocumentsModulesPath = Microsoft.PowerShell.Management\Join-Path -Path ([Environment]::GetFolderPath("MyDocuments")) -ChildPath "WindowsPowerShell\Modules"
+
+    $script:ProgramFilesModulesPath = Get-AllUsersModulesPath
+    $script:MyDocumentsModulesPath = Get-CurrentUserModulesPath
+    $script:PSGetLocalAppDataPath = Get-PSGetLocalAppDataPath
+    $script:TempPath = Get-TempPath
     $script:CurrentPSGetFormatVersion = "1.0"
 
     #Bootstrap NuGet binaries
@@ -56,6 +61,10 @@ function SuiteSetup {
 }
 
 function SuiteCleanup {
+    if($PSEdition -eq 'Core') {
+        return
+    }
+
     if(Test-Path $script:moduleSourcesBackupFilePath)
     {
         Move-Item $script:moduleSourcesBackupFilePath $script:moduleSourcesFilePath -Force
@@ -73,6 +82,11 @@ function SuiteCleanup {
 }
 
 Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
+
+    if($PSEdition -eq 'Core') {
+        Write-Verbose 'Skipping Publish Tests on PowerShell Core Edition'
+        return
+    }
 
     BeforeAll {
         SuiteSetup
@@ -118,15 +132,7 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: should be able to publish a module
     #
     It PublishModuleWithNameForSxSVersion {
-        
-        if(-not (Test-ModuleSxSVersionSupport))
-        {
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion) as Side-by-Side versioning is not supported."
-            return
-        }
-
         $version = "2.0"
-
         RemoveItem "$script:PublishModuleBase\*"
 
         $moduleBaseWithVersion = "$script:PublishModuleBase\$version"
@@ -142,7 +148,8 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
 
         $psgetItemInfo = Find-Module $script:PublishModuleName -RequiredVersion $version
         Assert (($psgetItemInfo.Name -eq $script:PublishModuleName) -and (($psgetItemInfo.Version.ToString() -eq $version))) "Publish-Module should publish a module with valid module name, $($psgetItemInfo.Name)"
-    }
+    } `
+    -Skip:$(-not (Test-ModuleSxSVersionSupport))
 
     # Purpose: Publish a module with -Name & -RequiredVersion and Module is created with SxS multi version support
     #
@@ -151,15 +158,7 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: should be able to publish a module
     #
     It PublishModuleWithNameRequiredVersionForSxSVersion {
-        
-        if(-not (Test-ModuleSxSVersionSupport))
-        {
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion) as Side-by-Side versioning is not supported."
-            return
-        }
-
         $version = "2.0"
-
         $moduleBaseWithVersion = "$script:PublishModuleBase\$version"
         $null = New-Item -Path $moduleBaseWithVersion -ItemType Directory -Force
         Set-Content "$moduleBaseWithVersion\$script:PublishModuleName.psm1" -Value "function Get-$script:PublishModuleName { Get-Date }"
@@ -180,7 +179,8 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
 
         $psgetItemInfo = Find-Module $script:PublishModuleName -RequiredVersion $version
         Assert (($psgetItemInfo.Name -eq $script:PublishModuleName) -and (($psgetItemInfo.Version.ToString() -eq $version))) "Publish-Module should publish a module with valid module name, $($psgetItemInfo.Name)"
-    }
+    } `
+    -Skip:$(-not (Test-ModuleSxSVersionSupport))
 
     # Purpose: Publish a module with -Path
     #
@@ -206,7 +206,7 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
         $version = "1.0"
         $moduleBase = $script:PublishModuleBase
 
-        if($PSVersionTable.PSVersion -gt [Version]"5.0")
+        if($PSVersionTable.PSVersion -gt '5.0.0')
         {
             $moduleBase = "$script:PublishModuleBase\$version"
             $null = New-Item -ItemType Directory -Path $moduleBase -Force
@@ -241,7 +241,7 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
         $moduleBase = Join-Path -Path $script:TempModulesPath -ChildPath $Name
         $moduleBaseWithoutVersion = $moduleBase
 
-        if($PSVersionTable.PSVersion -gt [Version]"5.0")
+        if($PSVersionTable.PSVersion -gt '5.0.0')
         {
             $moduleBase = "$moduleBase\$version"
         }
@@ -262,13 +262,6 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: should fail with AmbiguousModulePathToPublish error id
     #
     It "PublishModuleWithAmbiguousPathWithoutVersion" {
-        
-        if(-not (Test-ModuleSxSVersionSupport))
-        {
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion) as Side-by-Side versioning is not supported."
-            return
-        }
-
         $version1 = "1.0"
         $version2 = "2.0"
         $moduleBase = $script:PublishModuleBase
@@ -284,7 +277,8 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
 
         AssertFullyQualifiedErrorIdEquals -scriptblock {Publish-Module -Path $moduleBaseWithoutVersion -WarningAction SilentlyContinue}`
                                           -expectedFullyQualifiedErrorId 'AmbiguousModulePathToPublish,Publish-Module'
-    }
+    } `
+    -Skip:$(-not (Test-ModuleSxSVersionSupport))
 
     # Purpose: Publish a module with -Path and Module is created with SxS multi version support
     #
@@ -293,13 +287,6 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: should be able to publish a module
     #
     It PublishModuleWithPathForSxSVersion {
-        
-        if(-not (Test-ModuleSxSVersionSupport))
-        {
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion) as Side-by-Side versioning is not supported."
-            return
-        }
-
         $version = "2.0"
 
         $moduleBaseWithVersion = "$script:PublishModuleBase\$version"
@@ -318,7 +305,8 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
 
         $psgetItemInfo = Find-Module $script:PublishModuleName -RequiredVersion $version
         Assert (($psgetItemInfo.Name -eq $script:PublishModuleName) -and (($psgetItemInfo.Version.ToString() -eq $version))) "Publish-Module should publish a module with valid module name, $($psgetItemInfo.Name)"
-    }
+    } `
+    -Skip:$(-not (Test-ModuleSxSVersionSupport))
 
     # Purpose: PublishModuleWithConfirmAndNoToPrompt
     #
@@ -327,14 +315,7 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: module should not be published after confirming NO
     #
     It "PublishModuleWithConfirmAndNoToPrompt" {
-
-        if(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
-        {            
-            Write-Warning -Message "Skipped on OSVersion: $([System.Environment]::OSVersion.Version) with PSCulture: $PSCulture"
-            return
-        }
-
-        $outputPath = $env:temp
+        $outputPath = $script:TempPath
         $guid =  [system.guid]::newguid().tostring()
         $outputFilePath = Join-Path $outputPath "$guid"
         $runspace = CreateRunSpace $outputFilePath 1
@@ -371,7 +352,8 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
 
         AssertFullyQualifiedErrorIdEquals -scriptblock {Find-Module $script:PublishModuleName -RequiredVersion $version}`
                                           -expectedFullyQualifiedErrorId "NoMatchFoundForCriteria,Microsoft.PowerShell.PackageManagement.Cmdlets.FindPackage"
-    }
+    } `
+    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
 
     # Purpose: PublishModuleWithConfirmAndYesToPrompt
     #
@@ -380,14 +362,7 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: module should be published after confirming YES
     #
     It "PublishModuleWithConfirmAndYesToPrompt" {
-
-        if(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
-        {            
-            Write-Warning -Message "Skipped on OSVersion: $([System.Environment]::OSVersion.Version) with PSCulture: $PSCulture"
-            return
-        }
-
-        $outputPath = $env:temp
+        $outputPath = $script:TempPath
         $guid =  [system.guid]::newguid().tostring()
         $outputFilePath = Join-Path $outputPath "$guid"
         $runspace = CreateRunSpace $outputFilePath 1
@@ -424,7 +399,8 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
 
         $psgetItemInfo = Find-Module $script:PublishModuleName -RequiredVersion $version
         Assert (($psgetItemInfo.Name -eq $script:PublishModuleName) -or (($psgetItemInfo.Version.ToString() -eq $version))) "Publish-Module should publish a module with valid module name after confirming YES, $($psgetItemInfo.Name)"
-    }
+    } `
+    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
 
     # Purpose: PublishModuleWithWhatIf
     #
@@ -433,20 +409,13 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: module should not be published with -WhatIf
     #
     It "PublishModuleWithWhatIf" {
-
-        if(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
-        {            
-            Write-Warning -Message "Skipped on OSVersion: $([System.Environment]::OSVersion.Version) with PSCulture: $PSCulture"
-            return
-        }
-
         $version = "3.0"
         New-ModuleManifest -Path "$script:PublishModuleBase\$script:PublishModuleName.psd1" -ModuleVersion $version -Description "$script:PublishModuleName module"  -NestedModules "$script:PublishModuleName.psm1"
 
         #Copy module to $script:ProgramFilesModulesPath
         Copy-Item $script:PublishModuleBase $script:ProgramFilesModulesPath -Recurse -Force
 
-        $outputPath = $env:temp
+        $outputPath = $script:TempPath
         $guid =  [system.guid]::newguid().tostring()
         $outputFilePath = Join-Path $outputPath "$guid"
         $runspace = CreateRunSpace $outputFilePath 1
@@ -474,7 +443,8 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
 
         AssertFullyQualifiedErrorIdEquals -scriptblock {Find-Module $script:PublishModuleName -RequiredVersion $version}`
                                           -expectedFullyQualifiedErrorId "NoMatchFoundForCriteria,Microsoft.PowerShell.PackageManagement.Cmdlets.FindPackage"
-    }
+    } `
+    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
 
     # Purpose: Publish multiple versions of a module
     #
@@ -566,7 +536,7 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
     AliasesToExport = '*'
 }
 '@  
-        if($PSVersionTable.PSVersion -ge [Version]"5.1")
+        if($PSVersionTable.PSVersion -ge '5.1.0')
         {        
             Publish-Module -Path $script:PublishModuleBase -WarningAction SilentlyContinue
             $res = Find-Module -Name $script:PublishModuleName
@@ -712,13 +682,6 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: Publish operation should succeed and Find-Module should get the details as provided in PSData.
     #
     It PublishModulePSDataInManifestFile {
-
-        if($PSVersionTable.PSVersion -lt '5.0.0')
-        {            
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion)"
-            return
-        }
-
         $version = "1.0"
         $Description = "$script:PublishModuleName module"
         $ReleaseNotes = "$script:PublishModuleName release notes"
@@ -760,7 +723,8 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
         Assert       ($psgetItemInfo.Tags -contains $Tags[0]) "Tags ($($psgetItemInfo.Tags)) should contain the published one ($($Tags[0]))"
         Assert       ($psgetItemInfo.Tags -contains $Tags[1]) "Tags ($($psgetItemInfo.Tags)) should contain the published one ($($Tags[1]))"
         AssertEqualsCaseInsensitive $psgetItemInfo.LicenseUri $LicenseUri "LicenseUri should be same as the published one"
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
     # Purpose: Test Publish-Module cmdlet gets the PSData properties from the module manifest file and also with Uri objects specified to the cmdlet
     #
@@ -769,13 +733,6 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: Publish operation should succeed and Find-Module should get the details as provided in PSData and *Uri parameters.
     #
     It PublishModuleWithUriObjectsAndPSDataInManifestFile {
-
-        if($PSVersionTable.PSVersion -lt '5.0.0')
-        {            
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion)"
-            return
-        }
-
         $version = "1.0"
         $Description = "$script:PublishModuleName module"
         $ReleaseNotes = "$script:PublishModuleName release notes"
@@ -817,7 +774,8 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
         Assert       ($psgetItemInfo.Tags -contains $Tags[1]) "Tags ($($psgetItemInfo.Tags)) should contain the published one ($($Tags[1]))"
         AssertEquals $psgetItemInfo.LicenseUri $LicenseUri "LicenseUri should be same as the published one"
         Assert ($psgetItemInfo.PublishedDate -and ($psgetItemInfo.PublishedDate.GetType().Name -eq 'DateTime')) "PublishedDate is missing, $($psgetItemInfo.PublishedDate)"
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
     # Purpose: Validate *-Module cmdlets without PowerShellGetFormatVersion and old package format
     #
@@ -955,13 +913,6 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: Publish operation should succeed but throw warnings
     #
     It PublishModuleWithSupportedParameter {
-
-       if($PSCulture -ne 'en-US')
-       {
-           Write-Warning -Message "Skipped on PSCulture: $PSCulture"
-           return
-       }
-
        $version = "1.0"
        $Tags = "Tags"
        $LicenseUri = 'http://contoso.com/license'
@@ -981,7 +932,8 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
        Assert ("$wa".Contains("ProjectUri")) "Warning messages should include 'ProjectUri are now supported'"
        Assert ("$wa".Contains("IconUri")) "Warning messages should include 'IconUri is now supported'"
        Assert ("$wa".Contains("Tags")) "Warning messages should include 'Tags are now supported'"
-    }
+    } `
+    -Skip:$($PSCulture -ne 'en-US')
      
     # Purpose: Test Publish-Module cmdlet gives warnings if Cmdlets/Functions/DscResourcesToExport has "*" in manifest
     #
@@ -990,15 +942,8 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: Publish operation should succeed but throw warnings
     #
     It PublishModuleWithAsteriskInExportedProperties  {
-
-        if($PSCulture -ne 'en-US')
-        {
-            Write-Warning -Message "Skipped on PSCulture: $PSCulture"
-            return
-        }
-
         $ModuleName = "DscTestModule"
-        $TempModulesPath = "$env:TEMP\$(Get-Random)"
+        $TempModulesPath = "$script:TempPath\$(Get-Random)"
         $null = New-Item -Path $TempModulesPath -ItemType Directory -Force
     
 
@@ -1038,7 +983,7 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
         $version = "2.0"
         RemoveItem -path $manfiestFilePath
 
-        if($PSVersionTable.PSVersion -ge [Version]"5.0")
+        if($PSVersionTable.PSVersion -ge '5.0.0')
         {
             New-ModuleManifest -Path $manfiestFilePath `
                            -ModuleVersion $version  `
@@ -1072,7 +1017,7 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
         Assert ("$wa".Contains("exported cmdlets")) "Warning messages should include 'exported cmdlets'"
         Assert ("$wa".Contains("exported functions")) "Warning messages should include 'exported functions'"
         
-        if($PSVersionTable.PSVersion -ge [Version]"5.0")
+        if($PSVersionTable.PSVersion -ge '5.0.0')
         {
             Assert ("$wa".Contains("exported DscResources")) "Warning messages should include 'exported DscResources'"
         }
@@ -1082,10 +1027,16 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
         AssertEquals $itemInfo.Name 'DscTestModule' "Publish-Module was not able to populate the RoleCapability Names."
         Assert ($itemInfo.Includes.RoleCapability -contains 'Lev1Maintenance') "Publish-Module was not able to populate the RoleCapability Names: $($itemInfo.Includes.RoleCapability)"
         Assert ($itemInfo.Includes.RoleCapability -contains 'Lev2Maintenance') "Publish-Module was not able to populate the RoleCapability Names: $($itemInfo.Includes.RoleCapability)"
-    }
+    } `
+    -Skip:$($PSCulture -ne 'en-US')
 }
 
 Describe PowerShell.PSGet.PublishModuleTests.P1 -Tags 'P1','OuterLoop' {
+
+    if($PSEdition -eq 'Core') {
+        Write-Verbose 'Skipping Publish Tests on PowerShell Core Edition'
+        return
+    }
 
     BeforeAll {
         SuiteSetup
@@ -1179,20 +1130,12 @@ Describe PowerShell.PSGet.PublishModuleTests.P1 -Tags 'P1','OuterLoop' {
         Assert ($psgetItemInfo.Name -eq $script:PublishModuleName) "Publish-Module should publish a module with valid module path, $($psgetItemInfo.Name)"
     }
 
-    It "PublishModuleWithoutNugetExeAndNoToPrompt" -skip:($env:APPVEYOR_TEST_PASS -eq 'True') {
-
-        if(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
-        {            
-            Write-Warning -Message "Skipped on OSVersion: $([System.Environment]::OSVersion.Version) with PSCulture: $PSCulture"
-            return
-        }
-        
+    It "PublishModuleWithoutNugetExeAndNoToPrompt" {
         try {
-
             # Delete nuget.exe to test the prompt for installing nuget binaries.
             Remove-NuGetExe
 
-            $outputPath = $env:temp
+            $outputPath = $script:TempPath
             $guid =  [system.guid]::newguid().tostring()
             $outputFilePath = Join-Path $outputPath "$guid"
             $runspace = CreateRunSpace $outputFilePath 1
@@ -1208,26 +1151,21 @@ Describe PowerShell.PSGet.PublishModuleTests.P1 -Tags 'P1','OuterLoop' {
             Copy-Item $script:PublishModuleBase $script:ProgramFilesModulesPath -Recurse -Force
             $err = $null
 	
-            try
-                    {
-            $result = ExecuteCommand $runspace "Publish-Module -Name $script:PublishModuleName"
-        }
-            catch
-                    {
-            $err = $_
-        }
-            finally
-                                                    {                        
-            $fileName = "PromptForChoice-0.txt"
-            $path = join-path $outputFilePath $fileName
-            if(Test-Path $path)
-            {
-                $content = get-content $path
+            try {
+                $result = ExecuteCommand $runspace "Publish-Module -Name $script:PublishModuleName"
+            } catch {
+                $err = $_
+            } finally {                        
+                $fileName = "PromptForChoice-0.txt"
+                $path = join-path $outputFilePath $fileName
+                if(Test-Path $path)
+                {
+                    $content = get-content $path
+                }
+        
+                CloseRunSpace $runspace
+                RemoveItem $outputFilePath
             }
-	
-            CloseRunSpace $runspace
-            RemoveItem $outputFilePath
-        }
 	
             Assert ($err -and $err.Exception.Message.Contains('NuGet.exe')) "Prompt for installing nuget binaries is not working, $err"
             Assert ($content -and $content.Contains('NuGet.exe')) "Prompt for installing nuget binaries is not working, $content"
@@ -1238,21 +1176,15 @@ Describe PowerShell.PSGet.PublishModuleTests.P1 -Tags 'P1','OuterLoop' {
         finally {
             Install-NuGetBinaries
         }
-    }
+    } `
+    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core') -or ($env:APPVEYOR_TEST_PASS -eq 'True'))
 	
-    It "PublishModuleWithoutNugetExeAndYesToPrompt" -skip:($env:APPVEYOR_TEST_PASS -eq 'True') {
-
-        if(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
-        {            
-            Write-Warning -Message "Skipped on OSVersion: $([System.Environment]::OSVersion.Version) with PSCulture: $PSCulture"
-            return
-        }
-
+    It "PublishModuleWithoutNugetExeAndYesToPrompt" {
         try {
             # Delete nuget.exe to test the prompt for installing nuget binaries.
             Remove-NuGetExe
 
-            $outputPath = $env:temp
+            $outputPath = $script:TempPath
             $guid =  [system.guid]::newguid().tostring()
             $outputFilePath = Join-Path $outputPath "$guid"
             $runspace = CreateRunSpace $outputFilePath 1
@@ -1290,7 +1222,8 @@ Describe PowerShell.PSGet.PublishModuleTests.P1 -Tags 'P1','OuterLoop' {
         finally {
             Install-NuGetBinaries
         }
-    }
+    } `
+    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core') -or ($env:APPVEYOR_TEST_PASS -eq 'True'))
 
     # Purpose: PublishNotAvailableModule
     #
@@ -1330,7 +1263,7 @@ Describe PowerShell.PSGet.PublishModuleTests.P1 -Tags 'P1','OuterLoop' {
     # Expected Result: should fail
     #
     It "PublishInvalidModule" {
-        $tempmodulebase = "$env:Temp\$(Get-Random)\InvalidModule"
+        $tempmodulebase = "$script:TempPath\$(Get-Random)\InvalidModule"
         $null = New-Item $tempmodulebase -Force -ItemType Directory        
 
         try
@@ -1340,7 +1273,7 @@ Describe PowerShell.PSGet.PublishModuleTests.P1 -Tags 'P1','OuterLoop' {
 
             Set-Content "$tempmodulebase\InvalidModule.psm1" -Value "function foo {'foo'}"
 
-            if($PSVersionTable.PSVersion -ge [Version]"5.0")
+            if($PSVersionTable.PSVersion -ge '5.0.0')
             {
                 $errorId = 'InvalidModuleToPublish,Publish-Module'
             }
@@ -1366,7 +1299,7 @@ Describe PowerShell.PSGet.PublishModuleTests.P1 -Tags 'P1','OuterLoop' {
     # Expected Result: should fail
     #
     It "PublishInvalidModuleFilePath" {
-        $tempmodulebase = "$env:Temp\$(Get-Random)\InvalidModule\"
+        $tempmodulebase = "$script:TempPath\$(Get-Random)\InvalidModule\"
         $null = New-Item $tempmodulebase -Force -ItemType Directory
         $moduleFilePath = Join-Path $tempmodulebase "InvalidModule.psm1"
         Set-Content $moduleFilePath -Value "function foo {'foo'}"
@@ -1603,6 +1536,11 @@ Describe PowerShell.PSGet.PublishModuleTests.P1 -Tags 'P1','OuterLoop' {
 
 Describe PowerShell.PSGet.PublishModuleTests.P2 -Tags 'P2','OuterLoop' {
 
+    if($PSEdition -eq 'Core') {
+        Write-Verbose 'Skipping Publish Tests on PowerShell Core Edition'
+        return
+    }
+
     BeforeAll {
         SuiteSetup
     }
@@ -1652,7 +1590,7 @@ Describe PowerShell.PSGet.PublishModuleTests.P2 -Tags 'P2','OuterLoop' {
         $NestedRequiredModules2 = @('NestedRequiredModule1', 
                                     @{ModuleName = 'NestedRequiredModule2'; ModuleVersion = '2.0'; })
 
-        if($PSVersionTable.PSVersion -ge [Version]"5.0")
+        if($PSVersionTable.PSVersion -ge '5.0.0')
         {
             $DepencyModuleNames += @("RequiredModule3",
                                      "RequiredModule4",
@@ -1840,7 +1778,7 @@ Describe PowerShell.PSGet.PublishModuleTests.P2 -Tags 'P2','OuterLoop' {
         }
 
         # WarningVariable value doesnt get the warning messages on PS 3.0 and 4.0, known issue.
-        if($PSVersionTable.PSVersion -ge [Version]"5.0")
+        if($PSVersionTable.PSVersion -ge '5.0.0')
         {
             try
             {

--- a/Tests/PSGetPublishModule.Tests.ps1
+++ b/Tests/PSGetPublishModule.Tests.ps1
@@ -11,12 +11,11 @@
 
    The local directory based NuGet repository is used for publishing the modules.
 #>
+if($PSEdition -eq 'Core') {
+    return
+}
 
 function SuiteSetup {
-    if($PSEdition -eq 'Core') {
-        return
-    }
-
     Import-Module "$PSScriptRoot\PSGetTestUtils.psm1" -WarningAction SilentlyContinue
     Import-Module "$PSScriptRoot\Asserts.psm1" -WarningAction SilentlyContinue
 
@@ -61,10 +60,6 @@ function SuiteSetup {
 }
 
 function SuiteCleanup {
-    if($PSEdition -eq 'Core') {
-        return
-    }
-
     if(Test-Path $script:moduleSourcesBackupFilePath)
     {
         Move-Item $script:moduleSourcesBackupFilePath $script:moduleSourcesFilePath -Force
@@ -82,12 +77,6 @@ function SuiteCleanup {
 }
 
 Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
-
-    if($PSEdition -eq 'Core') {
-        Write-Verbose 'Skipping Publish Tests on PowerShell Core Edition'
-        return
-    }
-
     BeforeAll {
         SuiteSetup
     }
@@ -1033,11 +1022,6 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
 
 Describe PowerShell.PSGet.PublishModuleTests.P1 -Tags 'P1','OuterLoop' {
 
-    if($PSEdition -eq 'Core') {
-        Write-Verbose 'Skipping Publish Tests on PowerShell Core Edition'
-        return
-    }
-
     BeforeAll {
         SuiteSetup
     }
@@ -1535,11 +1519,6 @@ Describe PowerShell.PSGet.PublishModuleTests.P1 -Tags 'P1','OuterLoop' {
 }
 
 Describe PowerShell.PSGet.PublishModuleTests.P2 -Tags 'P2','OuterLoop' {
-
-    if($PSEdition -eq 'Core') {
-        Write-Verbose 'Skipping Publish Tests on PowerShell Core Edition'
-        return
-    }
 
     BeforeAll {
         SuiteSetup

--- a/Tests/PSGetPublishScript.Tests.ps1
+++ b/Tests/PSGetPublishScript.Tests.ps1
@@ -11,12 +11,11 @@
 
    The local directory based NuGet repository is used for publishing the modules.
 #>
+if($PSEdition -eq 'Core') {
+    return
+}
 
 function SuiteSetup {
-    if($PSEdition -eq 'Core') {
-        return
-    }
-
     Import-Module "$PSScriptRoot\PSGetTestUtils.psm1" -WarningAction SilentlyContinue
     Import-Module "$PSScriptRoot\Asserts.psm1" -WarningAction SilentlyContinue
     
@@ -67,10 +66,6 @@ function SuiteSetup {
 }
 
 function SuiteCleanup {
-    if($PSEdition -eq 'Core') {
-        return
-    }
-
     if(Test-Path $script:moduleSourcesBackupFilePath)
     {
         Move-Item $script:moduleSourcesBackupFilePath $script:moduleSourcesFilePath -Force
@@ -88,12 +83,6 @@ function SuiteCleanup {
 }
 
 Describe PowerShell.PSGet.PublishScriptTests -Tags 'BVT','InnerLoop' {
-
-    if($PSEdition -eq 'Core') {
-        Write-Verbose 'Skipping Publish Tests on PowerShell Core Edition'
-        return
-    }
-
     BeforeAll {
         SuiteSetup
     }
@@ -878,12 +867,6 @@ Describe PowerShell.PSGet.PublishScriptTests -Tags 'BVT','InnerLoop' {
 }
 
 Describe PowerShell.PSGet.PublishScriptTests.P1 -Tags 'P1','OuterLoop' {
-
-    if($PSEdition -eq 'Core') {
-        Write-Verbose 'Skipping Publish Tests on PowerShell Core Edition'
-        return
-    }
-
     BeforeAll {
         SuiteSetup
     }
@@ -1500,12 +1483,6 @@ Foo
 }
 
 Describe PowerShell.PSGet.PublishScriptTests.P2 -Tags 'P2','OuterLoop' {
-
-    if($PSEdition -eq 'Core') {
-        Write-Verbose 'Skipping Publish Tests on PowerShell Core Edition'
-        return
-    }
-
     BeforeAll {
         SuiteSetup
     }

--- a/Tests/PSGetPublishScript.Tests.ps1
+++ b/Tests/PSGetPublishScript.Tests.ps1
@@ -205,7 +205,7 @@ Describe PowerShell.PSGet.PublishScriptTests -Tags 'BVT','InnerLoop' {
         AssertFullyQualifiedErrorIdEquals -scriptblock {Find-Script $script:PublishScriptName -RequiredVersion $script:PublishScriptVersion}`
                                           -expectedFullyQualifiedErrorId "NoMatchFoundForCriteria,Microsoft.PowerShell.PackageManagement.Cmdlets.FindPackage"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ($PSCulture -ne 'en-US') -or ([System.Environment]::OSVersion.Version -lt '6.2.9200.0'))
 
     # Purpose: PublishScriptWithConfirmAndYesToPrompt
     #
@@ -247,7 +247,7 @@ Describe PowerShell.PSGet.PublishScriptTests -Tags 'BVT','InnerLoop' {
         AssertEquals $psgetItemInfo.Name $script:PublishScriptName "Publish-Script should publish a valid script after confirming YES, $($psgetItemInfo.Name)"
         AssertEquals $psgetItemInfo.Version $script:PublishScriptVersion "Publish-Script should publish a valid script after confirming YES, $($psgetItemInfo.Version)"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ($PSCulture -ne 'en-US') -or ([System.Environment]::OSVersion.Version -lt '6.2.9200.0'))
 
     # Purpose: PublishScriptWithWhatIf
     #
@@ -285,7 +285,7 @@ Describe PowerShell.PSGet.PublishScriptTests -Tags 'BVT','InnerLoop' {
         AssertFullyQualifiedErrorIdEquals -scriptblock {Find-Script $script:PublishScriptName -RequiredVersion $script:PublishScriptVersion}`
                                           -expectedFullyQualifiedErrorId "NoMatchFoundForCriteria,Microsoft.PowerShell.PackageManagement.Cmdlets.FindPackage"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ($PSCulture -ne 'en-US') -or ([System.Environment]::OSVersion.Version -lt '6.2.9200.0'))
 
     # Purpose: Test xml special characters are escaped when publishing a script
     #
@@ -1015,10 +1015,10 @@ Describe PowerShell.PSGet.PublishScriptTests.P1 -Tags 'P1','OuterLoop' {
         }
     } `
     -Skip:$(
-        ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or 
         ($PSCulture -ne 'en-US') -or 
         ($PSEdition -eq 'Core') -or
-        ($env:APPVEYOR_TEST_PASS -eq 'True')
+        ($env:APPVEYOR_TEST_PASS -eq 'True') -or
+        ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") 
     )
 	
     # Purpose: PublishNotAvailableScript
@@ -1667,10 +1667,10 @@ Describe PowerShell.PSGet.PublishScriptTests.P2 -Tags 'P2','OuterLoop' {
         }
     } `
     -Skip:$(
-        ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or 
         ($PSCulture -ne 'en-US') -or 
         ($PSEdition -eq 'Core') -or
-        ($env:APPVEYOR_TEST_PASS -eq 'True')
+        ($env:APPVEYOR_TEST_PASS -eq 'True') -or
+        ([System.Environment]::OSVersion.Version -lt "6.2.9200.0") 
     )
 
     # Purpose: Validate Publish-Script cmdlet with script dependencies

--- a/Tests/PSGetTestUtils.psm1
+++ b/Tests/PSGetTestUtils.psm1
@@ -520,7 +520,7 @@ function PublishDscTestModule
         $TestModulesBase
     )
 
-    $TempModulesPath = "$script:TempPath\$(Get-Random)"
+    $TempModulesPath = Join-Path $script:TempPath "$(Get-Random)"
     $null = New-Item -Path $TempModulesPath -ItemType Directory -Force
 
     Copy-Item -Path "$TestModulesBase\$ModuleName" -Destination $TempModulesPath -Recurse -Force
@@ -1149,7 +1149,7 @@ function Set-PATHVariableForScriptsInstallLocation
 function Get-CodeSigningCert
 {
     $cert = $null;
-    $scriptName = $script:TempPath + "\" + [IO.Path]::GetRandomFileName + ".ps1"  
+    $scriptName = Join-Path $script:TempPath  "$([IO.Path]::GetRandomFileName()).ps1"  
     "get-date" >$scriptName  
     $cert = @(get-childitem cert:\CurrentUser\My -codesigning | Where-Object {(Set-AuthenticodeSignature $scriptName -cert $_).Status -eq "Valid"})[0];  
     del $scriptName

--- a/Tests/PSGetTestUtils.psm1
+++ b/Tests/PSGetTestUtils.psm1
@@ -6,20 +6,61 @@
 
 . "$PSScriptRoot\uiproxy.ps1"
 
-$script:PSGetProgramDataPath ="$env:ProgramData\Microsoft\Windows\PowerShell\PowerShellGet"
-$script:PSGetLocalAppDataPath="$env:LOCALAPPDATA\Microsoft\Windows\PowerShell\PowerShellGet"
-$script:moduleSourcesFilePath="$script:PSGetLocalAppDataPath\PSRepositories.xml"
-$script:NuGetBinaryProgramDataPath="$env:ProgramFiles\PackageManagement\ProviderAssemblies"
 $script:NuGetClient = $null
 $script:NuGetExeName = 'NuGet.exe'
 $script:NuGetProvider = $null
 $script:NuGetProviderName = 'NuGet'
 $script:NuGetProviderVersion  = [Version]'2.8.5.201'
-$script:MyDocumentsModulesPath = Join-Path -Path ([Environment]::GetFolderPath("MyDocuments")) -ChildPath "WindowsPowerShell\Modules"
-$script:ProgramFilesModulesPath = Microsoft.PowerShell.Management\Join-Path -Path $env:ProgramFiles -ChildPath "WindowsPowerShell\Modules"
 $script:EnvironmentVariableTarget = @{ Process = 0; User = 1; Machine = 2 }
+
+$script:PowerShellGet = 'PowerShellGet'
+$script:IsInbox = $PSHOME.EndsWith('\WindowsPowerShell\v1.0', [System.StringComparison]::OrdinalIgnoreCase)
+$script:IsWindows = (-not (Get-Variable -Name IsWindows -ErrorAction Ignore)) -or $IsWindows
+$script:IsLinux = (Get-Variable -Name IsLinux -ErrorAction Ignore) -and $IsLinux
+$script:IsOSX = (Get-Variable -Name IsOSX -ErrorAction Ignore) -and $IsOSX
+$script:IsCoreCLR = (Get-Variable -Name IsCoreCLR -ErrorAction Ignore) -and $IsCoreCLR
+
+if($script:IsInbox) {
+    $script:ProgramFilesPSPath = Microsoft.PowerShell.Management\Join-Path -Path $env:ProgramFiles -ChildPath "WindowsPowerShell"
+} else {
+    $script:ProgramFilesPSPath = $PSHome
+}
+
+if($script:IsInbox) {
+    try {
+        $script:MyDocumentsFolderPath = [Environment]::GetFolderPath("MyDocuments")
+    } catch {
+        $script:MyDocumentsFolderPath = $null
+    }
+
+    $script:MyDocumentsPSPath = if($script:MyDocumentsFolderPath) {
+                                    Microsoft.PowerShell.Management\Join-Path -Path $script:MyDocumentsFolderPath -ChildPath "WindowsPowerShell"
+                                } else {
+                                    Microsoft.PowerShell.Management\Join-Path -Path $env:USERPROFILE -ChildPath "Documents\WindowsPowerShell"
+                                }
+} elseif($script:IsWindows) {
+    $script:MyDocumentsPSPath = Microsoft.PowerShell.Management\Join-Path -Path $HOME -ChildPath 'Documents\PowerShell'
+} else {
+    $script:MyDocumentsPSPath = Microsoft.PowerShell.Management\Join-Path -Path $HOME -ChildPath ".local/share/powershell"
+}
+
+$script:ProgramFilesModulesPath = Microsoft.PowerShell.Management\Join-Path -Path $script:ProgramFilesPSPath -ChildPath "Modules"
+$script:MyDocumentsModulesPath = Microsoft.PowerShell.Management\Join-Path -Path $script:MyDocumentsPSPath -ChildPath "Modules"
+$script:ProgramFilesScriptsPath = Microsoft.PowerShell.Management\Join-Path -Path $script:ProgramFilesPSPath -ChildPath "Scripts"
+$script:MyDocumentsScriptsPath = Microsoft.PowerShell.Management\Join-Path -Path $script:MyDocumentsPSPath -ChildPath "Scripts"
+$script:TempPath = if($script:IsWindows) { ([System.IO.DirectoryInfo]$env:TEMP).FullName } else { '/tmp' }
+
+if($script:IsWindows) {
+    $script:PSGetProgramDataPath = Microsoft.PowerShell.Management\Join-Path -Path $env:ProgramData -ChildPath 'Microsoft\Windows\PowerShell\PowerShellGet\'
+    $script:PSGetAppLocalPath = Microsoft.PowerShell.Management\Join-Path -Path $env:LOCALAPPDATA -ChildPath 'Microsoft\Windows\PowerShell\PowerShellGet\'
+} else {
+    $script:PSGetProgramDataPath = "$HOME/.config/powershell/powershellget"
+    $script:PSGetAppLocalPath = "$HOME/.config/powershell/powershellget"
+}
+
 $script:ProgramDataExePath = Microsoft.PowerShell.Management\Join-Path -Path $script:PSGetProgramDataPath -ChildPath $script:NuGetExeName
-$script:ApplocalDataExePath = Microsoft.PowerShell.Management\Join-Path -Path $script:PSGetLocalAppDataPath -ChildPath $script:NuGetExeName
+$script:ApplocalDataExePath = Microsoft.PowerShell.Management\Join-Path -Path $script:PSGetAppLocalPath -ChildPath $script:NuGetExeName
+$script:moduleSourcesFilePath="$script:PSGetAppLocalPath\PSRepositories.xml"
 
 # PowerShellGetFormatVersion will be incremented when we change the .nupkg format structure. 
 # PowerShellGetFormatVersion is in the form of Major.Minor.  
@@ -27,6 +68,30 @@ $script:ApplocalDataExePath = Microsoft.PowerShell.Management\Join-Path -Path $s
 # Major is incremented for the breaking change.
 $script:CurrentPSGetFormatVersion = "1.0"
 $script:PSGetFormatVersionPrefix = "PowerShellGetFormatVersion_"
+
+function Get-AllUsersModulesPath {
+    return $script:ProgramFilesModulesPath
+}
+
+function Get-CurrentUserModulesPath {
+    return $script:MyDocumentsModulesPath
+}
+
+function Get-AllUsersScriptsPath {
+    return $script:ProgramFilesScriptsPath
+}
+
+function Get-CurrentUserScriptsPath {
+    return $script:MyDocumentsScriptsPath
+}
+
+function Get-TempPath {
+    return $script:TempPath
+}
+
+function Get-PSGetLocalAppDataPath {
+    return $script:PSGetAppLocalPath
+}
 
 function GetAndSet-PSGetTestGalleryDetails
 {
@@ -58,7 +123,7 @@ function GetAndSet-PSGetTestGalleryDetails
         $ResolvedLocalSource = & $psgetModule Resolve-Location -Location $SourceUri -LocationParameterName 'SourceLocation'
 
         if($ResolvedLocalSource -and 
-           $PSVersionTable.PSVersion -ge [Version]"5.0" -and 
+           $PSVersionTable.PSVersion -ge '5.0.0' -and 
            [System.Environment]::OSVersion.Version -ge "6.2.9200.0" -and 
            $PSCulture -eq 'en-US')
         {
@@ -227,7 +292,7 @@ function CreateAndPublish-TestScript
 
         [Parameter()]
         [string]
-        $ScriptsPath = $env:TEMP
+        $ScriptsPath = $script:TempPath
     )
 
     $scriptFilePath = Join-Path -Path $ScriptsPath -ChildPath "$Name.ps1"
@@ -306,7 +371,7 @@ function CreateAndPublishTestModule
 
         [Parameter()]
         [string]
-        $ModulesPath = $env:TEMP       
+        $ModulesPath = $script:TempPath       
     )
 
     $ModuleBase = Join-Path $ModulesPath $ModuleName
@@ -390,7 +455,7 @@ function CreateAndPublishTestModule
                           WarningAction = 'SilentlyContinue'
                        }
 
-            if($PSVersionTable.PSVersion -ge [Version]"5.0")
+            if($PSVersionTable.PSVersion -ge '5.0.0')
             {
                 New-ModuleManifest -Path "$ModuleBase\$ModuleName.psd1" `
                                    -ModuleVersion $version `
@@ -455,7 +520,7 @@ function PublishDscTestModule
         $TestModulesBase
     )
 
-    $TempModulesPath = "$env:TEMP\$(Get-Random)"
+    $TempModulesPath = "$script:TempPath\$(Get-Random)"
     $null = New-Item -Path $TempModulesPath -ItemType Directory -Force
 
     Copy-Item -Path "$TestModulesBase\$ModuleName" -Destination $TempModulesPath -Recurse -Force
@@ -495,7 +560,7 @@ function PublishDscTestModule
 
         RemoveItem -path $manfiestFilePath
 
-        if($PSVersionTable.PSVersion -ge [Version]"5.0")
+        if($PSVersionTable.PSVersion -ge '5.0.0')
         {
             New-ModuleManifest -Path $manfiestFilePath `
                                -ModuleVersion $version  `
@@ -554,7 +619,7 @@ function CreateAndPublishTestModuleWithVersionFormat
 
         [Parameter()]
         [string]
-        $ModulesPath = $env:TEMP
+        $ModulesPath = $script:TempPath
     )
     
     $repo = Get-PSRepository -Name $Repository -ErrorVariable err
@@ -581,7 +646,7 @@ function CreateAndPublishTestModuleWithVersionFormat
 
     foreach($version in $Versions)
     {
-        if($PSVersionTable.PSVersion -ge [Version]"5.0")
+        if($PSVersionTable.PSVersion -ge '5.0.0')
         {
             New-ModuleManifest -Path "$ModuleBase\$ModuleName.psd1" `
                                -ModuleVersion $version `
@@ -876,9 +941,9 @@ function Set-PSGallerySourceLocation
     $moduleSource.PSTypeNames.Insert(0, "Microsoft.PowerShell.Commands.PSRepository")
     $PSGetModuleSources.Add("PSGallery", $moduleSource)
     
-    if(-not (Test-Path $script:PSGetLocalAppDataPath))
+    if(-not (Test-Path $script:PSGetAppLocalPath))
     {
-        $null = New-Item -Path $script:PSGetLocalAppDataPath `
+        $null = New-Item -Path $script:PSGetAppLocalPath `
                             -ItemType Directory -Force `
                             -ErrorAction SilentlyContinue `
                             -WarningAction SilentlyContinue `
@@ -897,7 +962,7 @@ function Test-ModuleSxSVersionSupport
 {
     # Side-by-Side module version is avialable on PowerShell 5.0 or later versions only
     # By default, PowerShell module versions will be installed/updated Side-by-Side.
-    $PSVersionTable.PSVersion -ge [Version]"5.0"
+    $PSVersionTable.PSVersion -ge '5.0.0'
 }
 
 function Reset-PATHVariableForScriptsInstallLocation
@@ -919,14 +984,19 @@ function Reset-PATHVariableForScriptsInstallLocation
         $WriteWarningMessages
     )
 
+    if(($PSEdition -eq 'Core') -and (-not $script:IsWindows)) {
+        Write-Verbose 'Set-PATHVariableForScriptsInstallLocation is not supported on Non-Windows platforms'
+        return
+    }
+
     if($Scope -eq 'AllUsers')
     {
-        $scopePath = "$env:ProgramFiles\WindowsPowerShell\Scripts"
+        $scopePath = $script:ProgramFilesScriptsPath
         $target = $script:EnvironmentVariableTarget.Machine
     }
     else
     {
-        $scopePath = "$HOME\Documents\WindowsPowerShell\Scripts"
+        $scopePath = $script:MyDocumentsScriptsPath
         $target = $script:EnvironmentVariableTarget.User
     }
     
@@ -1011,17 +1081,22 @@ function Set-PATHVariableForScriptsInstallLocation
         $OnlyProcessPathVariable
     )
 
+    if(($PSEdition -eq 'Core') -and (-not $script:IsWindows)) {
+        Write-Verbose 'Set-PATHVariableForScriptsInstallLocation is not supported on Non-Windows platforms'
+        return
+    }
+
     $psgetModule = Import-Module -Name PowerShellGet -PassThru -Scope Local -Verbose:$VerbosePreference
 
     # Check and add the scope path to PATH environment variable if USER accepts the prompt.
     if($Scope -eq 'AllUsers')
     {
-        $ScopePath = "$env:ProgramFiles\WindowsPowerShell\Scripts"
+        $ScopePath = $script:ProgramFilesScriptsPath
         $target = $script:EnvironmentVariableTarget.Machine
     }
     else
     {
-        $ScopePath = "$HOME\Documents\WindowsPowerShell\Scripts"
+        $ScopePath = $script:MyDocumentsScriptsPath
         $target = $script:EnvironmentVariableTarget.User
     }
 
@@ -1074,7 +1149,7 @@ function Set-PATHVariableForScriptsInstallLocation
 function Get-CodeSigningCert
 {
     $cert = $null;
-    $scriptName = $env:Temp + "\" + [IO.Path]::GetRandomFileName + ".ps1"  
+    $scriptName = $script:TempPath + "\" + [IO.Path]::GetRandomFileName + ".ps1"  
     "get-date" >$scriptName  
     $cert = @(get-childitem cert:\CurrentUser\My -codesigning | Where-Object {(Set-AuthenticodeSignature $scriptName -cert $_).Status -eq "Valid"})[0];  
     del $scriptName

--- a/Tests/PSGetUnInstallModule.Tests.ps1
+++ b/Tests/PSGetUnInstallModule.Tests.ps1
@@ -249,15 +249,11 @@ Describe 'PowerShell.PSGet.UnInstallModuleTests' -Tags 'BVT','InnerLoop' {
     #
     It "ValidateModuleIsInUseErrorDuringUninstallModule" {
         $NonAdminConsoleOutput = Join-Path $TestDrive 'nonadminconsole-out.txt'
-        Start-Process "$PSHOME\PowerShell.exe" -ArgumentList @'
-                                                               if($PSEdition -ne 'Core') {
-                                                                    $null = Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Scope CurrentUser;
-                                                                    $null = Import-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;
-                                                               }
-                                                               Install-Module -Name DscTestModule -Scope CurrentUser;
-                                                               Import-Module -Name DscTestModule;
-                                                               Uninstall-Module -Name DscTestModule
-'@ `
+        Start-Process "$PSHOME\PowerShell.exe" -ArgumentList '$null = Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Scope CurrentUser;
+                                                              $null = Import-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;
+                                                              Install-Module -Name DscTestModule -Scope CurrentUser;
+                                                              Import-Module -Name DscTestModule;
+                                                              Uninstall-Module -Name DscTestModule' `
                                                -Wait `
                                                -WorkingDirectory $PSHOME `
                                                -RedirectStandardOutput $NonAdminConsoleOutput

--- a/Tests/PSGetUnInstallModule.Tests.ps1
+++ b/Tests/PSGetUnInstallModule.Tests.ps1
@@ -113,7 +113,7 @@ Describe 'PowerShell.PSGet.UnInstallModuleTests' -Tags 'BVT','InnerLoop' {
         $mod = Get-InstalledModule ContosoServer
         Assert ($mod) "UnInstall-Module should not uninstall the module with -WhatIf option"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt '6.2.9200.0') -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ($PSCulture -ne 'en-US') -or ([System.Environment]::OSVersion.Version -lt '6.2.9200.0'))
 
     # Purpose: UnInstallModuleWithConfirmAndNoToPrompt
     #
@@ -157,7 +157,7 @@ Describe 'PowerShell.PSGet.UnInstallModuleTests' -Tags 'BVT','InnerLoop' {
         $mod = Get-InstalledModule ContosoServer
         Assert ($mod) "UnInstall-Module should not uninstall the module if confirm is not accepted"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt '6.2.9200.0') -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ($PSCulture -ne 'en-US') -or ([System.Environment]::OSVersion.Version -lt '6.2.9200.0'))
 
     # Purpose: UnInstallModuleWithConfirmAndYesToPrompt
     #
@@ -201,7 +201,7 @@ Describe 'PowerShell.PSGet.UnInstallModuleTests' -Tags 'BVT','InnerLoop' {
         $res = Get-InstalledModule ContosoServer -ErrorAction SilentlyContinue
         AssertNull $res "UnInstall-Module should uninstall a module if Confirm is not accepted"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt '6.2.9200.0') -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ($PSCulture -ne 'en-US') -or ([System.Environment]::OSVersion.Version -lt '6.2.9200.0'))
 
     <#
     Purpose: Validate the -AllVersions parameter on Get-InstalledModule and Uninstall-Module cmdlets

--- a/Tests/PSGetUnInstallModule.Tests.ps1
+++ b/Tests/PSGetUnInstallModule.Tests.ps1
@@ -278,6 +278,7 @@ Describe 'PowerShell.PSGet.UnInstallModuleTests' -Tags 'BVT','InnerLoop' {
             ($whoamiValue -eq "NT AUTHORITY\LOCAL SERVICE") -or
             ($whoamiValue -eq "NT AUTHORITY\NETWORK SERVICE") -or
             ($PSVersionTable.PSVersion -lt '4.0.0') -or
+            ($env:APPVEYOR_TEST_PASS -eq 'True') -or
             ($PSEdition -eq 'Core') -or
             ($PSCulture -ne 'en-US')
         )

--- a/Tests/PSGetUnInstallScript.Tests.ps1
+++ b/Tests/PSGetUnInstallScript.Tests.ps1
@@ -201,7 +201,7 @@ Describe PowerShell.PSGet.UninstallScriptTests -Tags 'BVT','InnerLoop' {
         $res = Get-InstalledScript Fabrikam-ServerScript
         Assert ($res) "Uninstall-Script should not uninstall the script with -WhatIf option"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt '6.2.9200.0') -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ($PSCulture -ne 'en-US') -or ([System.Environment]::OSVersion.Version -lt '6.2.9200.0'))
 
     # Purpose: UninstallScriptWithConfirmAndNoToPrompt
     #
@@ -245,7 +245,7 @@ Describe PowerShell.PSGet.UninstallScriptTests -Tags 'BVT','InnerLoop' {
         $res = Get-InstalledScript Fabrikam-ServerScript
         Assert ($res) "Uninstall-Script should not uninstall the script if confirm is not accepted"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt '6.2.9200.0') -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ($PSCulture -ne 'en-US') -or ([System.Environment]::OSVersion.Version -lt '6.2.9200.0'))
 
     # Purpose: UninstallScriptWithConfirmAndYesToPrompt
     #
@@ -289,7 +289,7 @@ Describe PowerShell.PSGet.UninstallScriptTests -Tags 'BVT','InnerLoop' {
         $res = Get-InstalledScript Fabrikam-ServerScript -ErrorAction SilentlyContinue
         AssertNull $res "Uninstall-Script should uninstall a script if Confirm is not accepted"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt '6.2.9200.0') -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ($PSCulture -ne 'en-US') -or ([System.Environment]::OSVersion.Version -lt '6.2.9200.0'))
 }
 
 Describe PowerShell.PSGet.UninstallScriptTests.ErrorCases -Tags 'P1','InnerLoop','RI' {

--- a/Tests/PSGetUnInstallScript.Tests.ps1
+++ b/Tests/PSGetUnInstallScript.Tests.ps1
@@ -18,9 +18,8 @@ function SuiteSetup {
     Import-Module "$PSScriptRoot\PSGetTestUtils.psm1" -WarningAction SilentlyContinue
     Import-Module "$PSScriptRoot\Asserts.psm1" -WarningAction SilentlyContinue
 
-    $script:MyDocumentsModulesPath = Join-Path -Path ([Environment]::GetFolderPath("MyDocuments")) -ChildPath "WindowsPowerShell\Modules"
-    $script:ProgramFilesModulesPath = Microsoft.PowerShell.Management\Join-Path -Path $env:ProgramFiles -ChildPath "WindowsPowerShell\Modules"
-    $script:PSGetLocalAppDataPath="$env:LOCALAPPDATA\Microsoft\Windows\PowerShell\PowerShellGet"
+    $script:PSGetLocalAppDataPath = Get-PSGetLocalAppDataPath
+    $script:TempPath = Get-TempPath
 
     #Bootstrap NuGet binaries
     Install-NuGetBinaries
@@ -41,13 +40,6 @@ function SuiteSetup {
     Get-InstalledScript -Name Fabrikam-ServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
     Get-InstalledScript -Name Fabrikam-ClientScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
 
-    $script:userName = "PSGetUser"
-    $password = "Password1"
-    $null = net user $script:userName $password /add
-    $secstr = ConvertTo-SecureString $password -AsPlainText -Force
-    $script:credential = new-object -typename System.Management.Automation.PSCredential -argumentlist $script:userName, $secstr
-    $script:assertTimeOutms = 20000
-
     $script:AddedAllUsersInstallPath    = Set-PATHVariableForScriptsInstallLocation -Scope AllUsers
     $script:AddedCurrentUserInstallPath = Set-PATHVariableForScriptsInstallLocation -Scope CurrentUser
 }
@@ -64,15 +56,6 @@ function SuiteCleanup {
 
     # Import the PowerShellGet provider to reload the repositories.
     $null = Import-PackageProvider -Name PowerShellGet -Force
-
-    # Delete the user
-    net user $script:UserName /delete | Out-Null
-    # Delete the user profile
-    $userProfile = (Get-WmiObject -Class Win32_UserProfile | Where-Object {$_.LocalPath -match $script:UserName})
-    if($userProfile)
-    {
-	    RemoveItem $userProfile.LocalPath
-    }
 
     if($script:AddedAllUsersInstallPath)
     {
@@ -187,13 +170,7 @@ Describe PowerShell.PSGet.UninstallScriptTests -Tags 'BVT','InnerLoop' {
     # Expected Result: it should not uninstall the script
     #
     It "UninstallScriptWithWhatIf" {
-        
-        if(([System.Environment]::OSVersion.Version -lt '6.2.9200.0') -or ($PSCulture -ne 'en-US')) { 
-            Write-Warning 'Skipped'
-            return
-        }
-
-        $outputPath = $env:temp
+        $outputPath = $script:TempPath
         $guid =  [system.guid]::newguid().tostring()
         $outputFilePath = Join-Path $outputPath "$guid"
         $runspace = CreateRunSpace $outputFilePath 1
@@ -223,7 +200,8 @@ Describe PowerShell.PSGet.UninstallScriptTests -Tags 'BVT','InnerLoop' {
 
         $res = Get-InstalledScript Fabrikam-ServerScript
         Assert ($res) "Uninstall-Script should not uninstall the script with -WhatIf option"
-    }
+    } `
+    -Skip:$(([System.Environment]::OSVersion.Version -lt '6.2.9200.0') -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
 
     # Purpose: UninstallScriptWithConfirmAndNoToPrompt
     #
@@ -232,13 +210,7 @@ Describe PowerShell.PSGet.UninstallScriptTests -Tags 'BVT','InnerLoop' {
     # Expected Result: script should not be uninstalled after confirming NO
     #
     It "UninstallScriptWithConfirmAndNoToPrompt" {
-        
-        if(([System.Environment]::OSVersion.Version -lt '6.2.9200.0') -or ($PSCulture -ne 'en-US')) { 
-            Write-Warning 'Skipped'
-            return
-        }
-        
-        $outputPath = $env:temp
+        $outputPath = $script:TempPath
         $guid =  [system.guid]::newguid().tostring()
         $outputFilePath = Join-Path $outputPath "$guid"
         $runspace = CreateRunSpace $outputFilePath 1
@@ -272,7 +244,8 @@ Describe PowerShell.PSGet.UninstallScriptTests -Tags 'BVT','InnerLoop' {
 
         $res = Get-InstalledScript Fabrikam-ServerScript
         Assert ($res) "Uninstall-Script should not uninstall the script if confirm is not accepted"
-    }
+    } `
+    -Skip:$(([System.Environment]::OSVersion.Version -lt '6.2.9200.0') -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
 
     # Purpose: UninstallScriptWithConfirmAndYesToPrompt
     #
@@ -281,13 +254,7 @@ Describe PowerShell.PSGet.UninstallScriptTests -Tags 'BVT','InnerLoop' {
     # Expected Result: script should be uninstalled after confirming YES
     #
     It "UninstallScriptWithConfirmAndYesToPrompt" {
-        
-        if(([System.Environment]::OSVersion.Version -lt '6.2.9200.0') -or ($PSCulture -ne 'en-US')) { 
-            Write-Warning 'Skipped'
-            return
-        }
-
-        $outputPath = $env:temp
+        $outputPath = $script:TempPath
         $guid =  [system.guid]::newguid().tostring()
         $outputFilePath = Join-Path $outputPath "$guid"
         $runspace = CreateRunSpace $outputFilePath 1
@@ -321,7 +288,8 @@ Describe PowerShell.PSGet.UninstallScriptTests -Tags 'BVT','InnerLoop' {
 
         $res = Get-InstalledScript Fabrikam-ServerScript -ErrorAction SilentlyContinue
         AssertNull $res "Uninstall-Script should uninstall a script if Confirm is not accepted"
-    }
+    } `
+    -Skip:$(([System.Environment]::OSVersion.Version -lt '6.2.9200.0') -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
 }
 
 Describe PowerShell.PSGet.UninstallScriptTests.ErrorCases -Tags 'P1','InnerLoop','RI' {

--- a/Tests/PSGetUpdateModule.Tests.ps1
+++ b/Tests/PSGetUpdateModule.Tests.ps1
@@ -18,9 +18,10 @@ function SuiteSetup {
     Import-Module "$PSScriptRoot\PSGetTestUtils.psm1" -WarningAction SilentlyContinue
     Import-Module "$PSScriptRoot\Asserts.psm1" -WarningAction SilentlyContinue
 
-    $script:MyDocumentsModulesPath = Join-Path -Path ([Environment]::GetFolderPath("MyDocuments")) -ChildPath "WindowsPowerShell\Modules"
-    $script:PSGetLocalAppDataPath="$env:LOCALAPPDATA\Microsoft\Windows\PowerShell\PowerShellGet"
-        
+    $script:MyDocumentsModulesPath = Get-CurrentUserModulesPath
+    $script:PSGetLocalAppDataPath = Get-PSGetLocalAppDataPath
+    $script:TempPath = Get-TempPath
+
     #Bootstrap NuGet binaries
     Install-NuGetBinaries
 
@@ -39,11 +40,14 @@ function SuiteSetup {
     PSGetTestUtils\Uninstall-Module ContosoServer
     PSGetTestUtils\Uninstall-Module ContosoClient
 
-    $script:userName = "PSGetUser"
-    $password = "Password1"
-    $null = net user $script:userName $password /add
-    $secstr = ConvertTo-SecureString $password -AsPlainText -Force
-    $script:credential = new-object -typename System.Management.Automation.PSCredential -argumentlist $script:userName, $secstr
+    if($PSEdition -ne 'Core')
+    {
+        $script:userName = "PSGetUser"
+        $password = "Password1"
+        $null = net user $script:userName $password /add
+        $secstr = ConvertTo-SecureString $password -AsPlainText -Force
+        $script:credential = new-object -typename System.Management.Automation.PSCredential -argumentlist $script:userName, $secstr
+    }
     $script:assertTimeOutms = 20000
 }
 
@@ -60,13 +64,16 @@ function SuiteCleanup {
     # Import the PowerShellGet provider to reload the repositories.
     $null = Import-PackageProvider -Name PowerShellGet -Force
 
-    # Delete the user
-    net user $script:UserName /delete | Out-Null
-    # Delete the user profile
-    $userProfile = (Get-WmiObject -Class Win32_UserProfile | Where-Object {$_.LocalPath -match $script:UserName})
-    if($userProfile)
+    if($PSEdition -ne 'Core')
     {
-	    RemoveItem $userProfile.LocalPath
+        # Delete the user
+        net user $script:UserName /delete | Out-Null
+        # Delete the user profile
+        $userProfile = (Get-WmiObject -Class Win32_UserProfile | Where-Object {$_.LocalPath -match $script:UserName})
+        if($userProfile)
+        {
+            RemoveItem $userProfile.LocalPath
+        }
     }
 }
 
@@ -92,17 +99,10 @@ Describe PowerShell.PSGet.UpdateModuleTests -Tags 'BVT','InnerLoop' {
     # Expected Result: module should not be updated -WhatIf
     #
     It "UpdateModuleWithWhatIf" {
-
-        if(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
-        {            
-            Write-Warning -Message "Skipped on OSVersion: $([System.Environment]::OSVersion.Version) with PSCulture: $PSCulture"
-            return
-        }
-
         $installedVersion = "1.0"
         Install-Module ContosoServer -RequiredVersion $installedVersion
 
-        $outputPath = $env:temp
+        $outputPath = $script:TempPath
         $guid =  [system.guid]::newguid().tostring()
         $outputFilePath = Join-Path $outputPath "$guid"
         $runspace = CreateRunSpace $outputFilePath 1
@@ -132,7 +132,8 @@ Describe PowerShell.PSGet.UpdateModuleTests -Tags 'BVT','InnerLoop' {
 
         $res = Get-Module ContosoServer -ListAvailable
         Assert (($res.Count -eq 1) -and ($res.Name -eq "ContosoServer") -and ($res.Version -eq [Version]"1.0")) "Update-Module should not update the module with -WhatIf option"
-    }
+    } `
+    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
 
     # Purpose: UpdateModuleWithFalseConfirm
     #
@@ -471,18 +472,11 @@ Describe PowerShell.PSGet.UpdateModuleTests.P2 -Tags 'P2','OuterLoop' {
     # Expected Result: module should not be updated after confirming NO
     #
     It "UpdateModuleWithConfirmAndNoToPrompt" {
-
-        if(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
-        {            
-            Write-Warning -Message "Skipped on OSVersion: $([System.Environment]::OSVersion.Version) with PSCulture: $PSCulture"
-            return
-        }
-
         $installedVersion = "1.0"
         Install-Module ContosoServer -RequiredVersion $installedVersion
         $installedVersion = "1.5"
         Install-Module ContosoServer -RequiredVersion $installedVersion -Force
-        $outputPath = $env:temp
+        $outputPath = $script:TempPath
         $guid =  [system.guid]::newguid().tostring()
         $outputFilePath = Join-Path $outputPath "$guid"
         $runspace = CreateRunSpace $outputFilePath 1
@@ -515,7 +509,8 @@ Describe PowerShell.PSGet.UpdateModuleTests.P2 -Tags 'P2','OuterLoop' {
 
         $res = Get-InstalledModule -Name ContosoServer
         Assert (($res.Name -eq "ContosoServer") -and ($res.Version -eq ([Version]$installedVersion))) "Update-Module should not update the ContosoServer module when pressed NO to Confirm."
-    }
+    } `
+    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
 
     # Purpose: UpdateModuleWithConfirmAndYesToPrompt
     #
@@ -524,16 +519,9 @@ Describe PowerShell.PSGet.UpdateModuleTests.P2 -Tags 'P2','OuterLoop' {
     # Expected Result: module should be updated after confirming YES
     #
     It "UpdateModuleWithConfirmAndYesToPrompt" {
-
-        if(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
-        {            
-            Write-Warning -Message "Skipped on OSVersion: $([System.Environment]::OSVersion.Version) with PSCulture: $PSCulture"
-            return
-        }
-
         $installedVersion = "1.0"
         Install-Module ContosoServer -RequiredVersion $installedVersion
-        $outputPath = $env:temp
+        $outputPath = $script:TempPath
         $guid =  [system.guid]::newguid().tostring()
         $outputFilePath = Join-Path $outputPath "$guid"
         $runspace = CreateRunSpace $outputFilePath 1
@@ -574,7 +562,8 @@ Describe PowerShell.PSGet.UpdateModuleTests.P2 -Tags 'P2','OuterLoop' {
         }
 
         Assert (($res.Count -eq 1) -and ($res.Name -eq "ContosoServer") -and ($res.Version -gt [Version]"1.0")) "Update-Module should not update the ContosoServer module when pressed NO to Confirm."
-    }
+    } `
+    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
 
     # Purpose: AdminPrivilegesAreRequiredForUpdatingAllUsersModule
     #
@@ -583,19 +572,6 @@ Describe PowerShell.PSGet.UpdateModuleTests.P2 -Tags 'P2','OuterLoop' {
     # Expected Result: should fail with an error
     #
     It "AdminPrivilegesAreRequiredForUpdatingAllUsersModule" {
-    
-        $whoamiValue = (whoami)
-
-        if( ($whoamiValue -eq "NT AUTHORITY\SYSTEM") -or
-            ($whoamiValue -eq "NT AUTHORITY\LOCAL SERVICE") -or
-            ($whoamiValue -eq "NT AUTHORITY\NETWORK SERVICE") -or
-            ($PSVersionTable.PSVersion -lt [Version]"4.0") )
-        {
-
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion) for user $whoamiValue"
-            return
-        }
-
         Install-Module -Name ContosoServer -RequiredVersion 1.0
         $NonAdminConsoleOutput = Join-Path $TestDrive 'nonadminconsole-out.txt'
         Start-Process "$PSHOME\PowerShell.exe" -ArgumentList '$null = Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Scope CurrentUser;
@@ -609,7 +585,16 @@ Describe PowerShell.PSGet.UpdateModuleTests.P2 -Tags 'P2','OuterLoop' {
         $content = Get-Content $NonAdminConsoleOutput
         Assert ($content -match "AdminPrivilegesAreRequiredForUpdate") "update-module should fail when non-admin user is trying to update a module installed to alluser scope, $content"
         RemoveItem $NonAdminConsoleOutput
-    }
+    } `
+    -Skip:$(
+        $whoamiValue = (whoami)
+
+        ($whoamiValue -eq "NT AUTHORITY\SYSTEM") -or
+        ($whoamiValue -eq "NT AUTHORITY\LOCAL SERVICE") -or
+        ($whoamiValue -eq "NT AUTHORITY\NETWORK SERVICE") -or
+        ($PSEdition -eq 'Core') -or
+        ($PSVersionTable.PSVersion -lt '4.0.0')
+    )
 
     # Purpose: Validate Update-Module cmdlet with a module with dependencies
     #
@@ -640,7 +625,7 @@ Describe PowerShell.PSGet.UpdateModuleTests.P2 -Tags 'P2','OuterLoop' {
             Assert ($DepModuleDetails.Count -ge $DepencyModuleNames.Count)  "$DepencyModuleNames dependencies is not installed properly"
 
 
-            if($PSVersionTable.PSVersion -ge [Version]"5.0")
+            if($PSVersionTable.PSVersion -ge '5.0.0')
             {
                 $res2 | ForEach-Object {
                     $mod = Get-InstalledModule -Name $_.Name -MinimumVersion $_.Version
@@ -708,7 +693,7 @@ Describe PowerShell.PSGet.UpdateModuleTests.P2 -Tags 'P2','OuterLoop' {
             AssertNotNull $DepModuleDetails "$DepencyModuleNames dependencies is not updated properly"
             Assert ($DepModuleDetails.Count -ge $DepencyModuleNames.Count)  "$DepencyModuleNames dependencies is not installed properly"
 
-            if($PSVersionTable.PSVersion -ge [Version]"5.0")
+            if($PSVersionTable.PSVersion -ge '5.0.0')
             {
                 $depModuleDetails = $res3.Dependencies | Where-Object {$_.Name -eq 'NestedRequiredModule2'}
                 $mod = Get-InstalledModule -Name $depModuleDetails.Name `

--- a/Tests/PSGetUpdateModule.Tests.ps1
+++ b/Tests/PSGetUpdateModule.Tests.ps1
@@ -133,7 +133,7 @@ Describe PowerShell.PSGet.UpdateModuleTests -Tags 'BVT','InnerLoop' {
         $res = Get-Module ContosoServer -ListAvailable
         Assert (($res.Count -eq 1) -and ($res.Name -eq "ContosoServer") -and ($res.Version -eq [Version]"1.0")) "Update-Module should not update the module with -WhatIf option"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ($PSCulture -ne 'en-US') -or ([System.Environment]::OSVersion.Version -lt '6.2.9200.0'))
 
     # Purpose: UpdateModuleWithFalseConfirm
     #
@@ -510,7 +510,7 @@ Describe PowerShell.PSGet.UpdateModuleTests.P2 -Tags 'P2','OuterLoop' {
         $res = Get-InstalledModule -Name ContosoServer
         Assert (($res.Name -eq "ContosoServer") -and ($res.Version -eq ([Version]$installedVersion))) "Update-Module should not update the ContosoServer module when pressed NO to Confirm."
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ($PSCulture -ne 'en-US') -or ([System.Environment]::OSVersion.Version -lt '6.2.9200.0'))
 
     # Purpose: UpdateModuleWithConfirmAndYesToPrompt
     #
@@ -563,7 +563,7 @@ Describe PowerShell.PSGet.UpdateModuleTests.P2 -Tags 'P2','OuterLoop' {
 
         Assert (($res.Count -eq 1) -and ($res.Name -eq "ContosoServer") -and ($res.Version -gt [Version]"1.0")) "Update-Module should not update the ContosoServer module when pressed NO to Confirm."
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ($PSCulture -ne 'en-US') -or ([System.Environment]::OSVersion.Version -lt '6.2.9200.0'))
 
     # Purpose: AdminPrivilegesAreRequiredForUpdatingAllUsersModule
     #

--- a/Tests/PSGetUpdateModuleManifest.Tests.ps1
+++ b/Tests/PSGetUpdateModuleManifest.Tests.ps1
@@ -836,7 +836,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         $moduleInfo = Test-ModuleManifest -Path $script:testManifestPath
         AssertEquals $moduleInfo.ReleaseNotes $ReleaseNotes "ReleaseNotes should be $($ReleaseNotes)"
     } `
-    -Skip:$(($PSVersionTable.PSVersion -lt '5.0.0') -and ($env:APPVEYOR_TEST_PASS -eq 'True'))
+    -Skip:$(($PSVersionTable.PSVersion -lt '5.0.0') -or ($env:APPVEYOR_TEST_PASS -eq 'True'))
 
     # Purpose: Validate Update-ModuleManifest cmdlet throw warnings when CompatiblePSEditions is specified for PowerShell version lower than 5.1
     #

--- a/Tests/PSGetUpdateModuleManifest.Tests.ps1
+++ b/Tests/PSGetUpdateModuleManifest.Tests.ps1
@@ -16,13 +16,13 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
     BeforeAll {
         Import-Module "$PSScriptRoot\PSGetTestUtils.psm1" -WarningAction SilentlyContinue
         Import-Module "$PSScriptRoot\Asserts.psm1" -WarningAction SilentlyContinue
-
+        $script:TempPath = Get-TempPath
         $script:psgetModuleInfo = Import-Module PowerShellGet -Global -Force -Passthru
     }
 
     BeforeEach {
         # Create temp moduleManifest to be updated
-        $script:TempModulesPath="$env:LocalAppData\temp\PSGet_$(Get-Random)"
+        $script:TempModulesPath="$script:TempPath\PSGet_$(Get-Random)"
         $null = New-Item -Path $script:TempModulesPath -ItemType Directory -Force
 
         $script:UpdateModuleManifestName = "ContosoPublishModule"
@@ -89,7 +89,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         Assert ($newModuleInfo.ExportedAliases.Keys -contains "fimo") "ExportedAliases should include 'fimo')"
         Assert ($newModuleInfo.ExportedAliases.Keys -contains "upmo") "ExportedAliases should include 'upmo')"
         Assert ($newModuleInfo.ExportedAliases.Keys -contains "pumo") "ExportedAliases should include 'pumo')"
-        if($PSVersionTable.Version -ge [Version]"5.0")
+        if($PSVersionTable.Version -ge '5.0.0')
         {
             AssertEquals $newModuleInfo.Tags.Count $oldModuleInfo.Tags.Count "Tags count should be $($oldModuleInfo.Tags.Count)"
         }
@@ -162,7 +162,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         $VariablesToExport = "var1","var2"
         $CmdletsToExport="get-test1","get-test2"
         $HelpInfoURI = "$script:PublishModuleName URL"
-        $RequiredModules = @("BitsTransfer",@{ModuleName='PSScheduledJob';ModuleVersion='1.0.0.0';GUID='50cdb55f-5ab7-489f-9e94-4ec21ff51e59'})
+        $RequiredModules = @('Microsoft.PowerShell.Management',@{ModuleName='Microsoft.PowerShell.Utility';ModuleVersion='1.0.0.0';GUID='1da87e53-152b-403e-98dc-74d7b4d63d59'})
         $NestedModules = "Microsoft.PowerShell.Management","Microsoft.PowerShell.Utility"
         $ScriptsToProcess = "$script:UpdateModuleManifestName.ps1"
         $ParamsV3 = @{}
@@ -198,12 +198,12 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         $ParamsV5.Add("ReleaseNotes",$ReleaseNotes)
 
 
-        if($PSVersionTable.PSVersion -ge [Version]"3.0" -and $PSVersionTable.Version -le [Version]"4.0")
+        if($PSVersionTable.PSVersion -ge '3.0.0' -and $PSVersionTable.Version -le '4.0.0')
         {
             New-ModuleManifest  @ParamsV3 -Confirm:$false 
             Update-ModuleManifest @ParamsV3 -Confirm:$false
         }
-        elseif($PSVersionTable.PSVersion -ge [Version]"5.0")
+        elseif($PSVersionTable.PSVersion -ge '5.0.0')
         {
             New-ModuleManifest  @ParamsV5 -Confirm:$false 
             Update-ModuleManifest @ParamsV5 -Confirm:$false
@@ -234,7 +234,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         Assert ($newModuleInfo.ExportedVariables.Keys -contains $VariablesToExport[1]) "ExportedVariables should include $($VariablesToExport[1])"
         Assert ($newModuleInfo.ExportedCmdlets.Keys -contains ($CmdletsToExport[0])) "CmdletsToExport should contain $($CmdletsToExport[0])"
         Assert ($newModuleInfo.ExportedCmdlets.Keys -contains ($CmdletsToExport[1])) "CmdletsToExport should contain $($CmdletsToExport[1])"
-        if($PSVersionTable.Version -gt [Version]"5.0")
+        if($PSVersionTable.Version -gt '5.0.0')
         {
             Assert ($newModuleInfo.Tags -contains $Tags[0]) "Tags should include $($Tags[0])"
             Assert ($newModuleInfo.Tags -contains $Tags[1]) "Tags should include $($Tags[1])"
@@ -285,9 +285,9 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         $VariablesToExport = "var1","var2"
         $CmdletsToExport="get-test1","get-test2"
         $HelpInfoURI = "$script:PublishModuleName URL"
-        $RequiredModules = @("BitsTransfer",@{ModuleName='PSScheduledJob';ModuleVersion='1.0.0.0';GUID='50cdb55f-5ab7-489f-9e94-4ec21ff51e59'})
+        $RequiredModules = @('Microsoft.PowerShell.Management',@{ModuleName='Microsoft.PowerShell.Utility';ModuleVersion='1.0.0.0';GUID='1da87e53-152b-403e-98dc-74d7b4d63d59'})
         $NestedModules = "Microsoft.PowerShell.Management","Microsoft.PowerShell.Utility"
-        $ExternalModuleDependencies = "Microsoft.PowerShell.Management","PSScheduledJob"
+        $ExternalModuleDependencies = "Microsoft.PowerShell.Management","Microsoft.PowerShell.Utility"
 
         $ParamsV3 = @{}
         $ParamsV3.Add("Guid",$Guid)
@@ -321,12 +321,12 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         $ParamsV5.Add("IconUri",$IconUri)
         $ParamsV5.Add("ReleaseNotes",$ReleaseNotes)
 
-        if($PSVersionTable.PSVersion -ge [Version]"3.0" -or $PSVersionTable.Version -le [Version]"4.0")
+        if(($PSVersionTable.PSVersion -ge '3.0.0') -or ($PSVersionTable.Version -le '4.0.0'))
         {
             New-ModuleManifest  -path $script:testManifestPath -Confirm:$false 
             Update-ModuleManifest @ParamsV3 -Confirm:$false
         }
-        elseif($PSVersionTable.PSVersion -ge [Version]"5.0")
+        elseif($PSVersionTable.PSVersion -ge '5.0.0')
         {
             New-ModuleManifest  -path $script:testManifestPath -Confirm:$false 
             Update-ModuleManifest @ParamsV5 -Confirm:$false
@@ -355,7 +355,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         Assert ($newModuleInfo.ExportedVariables.Keys -contains $VariablesToExport[1]) "ExportedVariables should include $($VariablesToExport[1])"
         Assert ($newModuleInfo.ExportedCmdlets.Keys -contains ($CmdletsToExport[0])) "CmdletsToExport should contain $($CmdletsToExport[0])"
         Assert ($newModuleInfo.ExportedCmdlets.Keys -contains ($CmdletsToExport[1])) "CmdletsToExport should contain $($CmdletsToExport[1])"
-        if($PSVersionTable.Version -gt [Version]"5.0")
+        if($PSVersionTable.Version -gt '5.0.0')
         {
             Assert ($newModuleInfo.Tags -contains $Tags[0]) "Tags should include $($Tags[0])"
             Assert ($newModuleInfo.Tags -contains $Tags[1]) "Tags should include $($Tags[1])"
@@ -400,7 +400,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         
         $newModuleInfo = Test-ModuleManifest -Path $script:testManifestPath
 
-        if($PSVersionTable.PSVersion -ge [Version]"5.0")
+        if($PSVersionTable.PSVersion -ge '5.0.0')
         {
             Assert ($newModuleInfo.Tags -contains $Tags[0]) "Tags should include $($Tags[0])"
             Assert ($newModuleInfo.Tags -contains $Tags[1]) "Tags should include $($Tags[1])"
@@ -451,7 +451,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
     #
      It UpdateModuleManifesWithExportedDSCResourcesInLowerPowerShellVersion {
         #When running on lower versin of PowerShell
-        if($PSVersionTable.PSVersion -lt [Version]"5.0")
+        if($PSVersionTable.PSVersion -lt '5.0.0')
         {
             $DscResourcesToExport = "ExportedDscResource1"
 
@@ -485,7 +485,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
     # Expected Result: Update-ModuleManifest should update the field "DscResourcesToExport" in module manifest file.
     #
     It UpdateModuleManifestWithValidExportedDSCResources {
-        if($PSVersionTable.PSVersion -ge [Version]"5.0")
+        if($PSVersionTable.PSVersion -ge '5.0.0')
         {
             $DscResourcesToExport = "ExportedDscResource1","ExportedDscResources2"
 
@@ -546,7 +546,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         New-ModuleManifest -path $script:testManifestPath -FileList $FilePath
 
         # When running on lower versin of PowerShell
-        if($PSVersionTable.PSVersion -lt [Version]'5.1')
+        if($PSVersionTable.PSVersion -lt '5.1.0')
         {
             AssertFullyQualifiedErrorIdEquals -scriptblock {Update-ModuleManifest -Path $script:testManifestPath} `
                                           -expectedFullyQualifiedErrorId "FilePathInFileListNotWithinModuleBase,Update-ModuleManifest"
@@ -633,14 +633,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
     # Expected Result: Manifest contents should not be updated
     #
     It UpdateModuleManifestWithWhatIf {
-
-        if($PSCulture -ne 'en-US')
-        {
-            Write-Warning -Message "Skipped on PSCulture: $PSCulture"
-            return
-        }
-
-        $outputPath = $env:temp
+        $outputPath = $script:TempPath
         $guid =  [system.guid]::newguid().tostring()
         $outputFilePath = Join-Path $outputPath "$guid"
         $runspace = CreateRunSpace $outputFilePath 1
@@ -674,7 +667,8 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         Assert ($content -and $content.Contains("Update manifest file with new content")) "Update-ModouleManifest whatif message missing, $content"
         Assert $content.Contains("Author = 'NewAuthor'") "Update-ModuleManifest whatif message missing changing value, $content"
         AssertEquals $moduleInfo.Author $Author "Author name should be $($Author)"
-    }
+    } `
+    -Skip:$(($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
 
 
     # Purpose: Validate Update-ModuleManifest will update the content if -Confirm:$false is used
@@ -700,8 +694,8 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
     #
     # Expected Result: Manifest file should be updated
     #
-    It "UpdateModuleManifestWithConfirmAndYesToPrompt" {
-        $outputPath = $env:temp
+    It "UpdateModuleManifestWithConfirmAndYesToPrompt" -Test {
+        $outputPath = $script:TempPath
         $guid =  [system.guid]::newguid().tostring()
         $outputFilePath = Join-Path $outputPath "$guid"
         $runspace = CreateRunSpace $outputFilePath 1
@@ -733,8 +727,8 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
 
         $newModuleInfo = Test-ModuleManifest -Path $script:testManifestPath
         AssertEquals $newModuleInfo.Author $newAuthor "Author name should be $($newAuthor)"
-    } 
-
+    } `
+    -Skip:$($PSEdition -eq 'Core')
     
     # Purpose: Validate Update-ModuleManifest will throw errors if current user does not have read-write permission 
     #
@@ -776,20 +770,14 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
     # Expected Result: Update-ModuleManifest should update the manifest with correct ReleaseNotes with escape characters
     #
     It UpdateModuleManifestWithSingleQuoteInReleaseNotes {
-
-        if($PSVersionTable.PSVersion -lt '5.0.0')
-        {            
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion)"
-            return
-        }
-
         New-ModuleManifest -path $script:testManifestPath 
         $ReleaseNotes = "I'm a test"
         Update-ModuleManifest -Path $script:testManifestPath -ReleaseNotes $ReleaseNotes
         
         $moduleInfo = Test-ModuleManifest -Path $script:testManifestPath
         AssertEquals $moduleInfo.ReleaseNotes "I'm a test" "ReleaseNotes should be $($ReleaseNotes)"
-    } 
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0') 
 
     # Purpose: Validate Update-ModuleManifest have proper ReleaseNotes field when there are existing releaseNotes value
     # with single quotes
@@ -800,13 +788,6 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
     # Expected Result: Update-ModuleManifest should update the manifest with correct ReleaseNotes with escape characters
     #
     It UpdateModuleManifestWithSingleQuoteInExistingReleaseNotes {
-
-        if($PSVersionTable.PSVersion -lt '5.0.0')
-        {            
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion)"
-            return
-        }
-
         $ReleaseNotes = "I'm a test"
         New-ModuleManifest -path $script:testManifestPath -ReleaseNotes $ReleaseNotes
         
@@ -814,7 +795,8 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         
         $moduleInfo = Test-ModuleManifest -Path $script:testManifestPath
         AssertEquals $moduleInfo.ReleaseNotes "I'm a test" "ReleaseNotes should be $($ReleaseNotes)"
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
     # Purpose: Validate Update-ModuleManifest have proper ReleaseNotes field when there are multiple lines of ReleaseNotes
     #
@@ -824,13 +806,6 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
     # Expected Result: Update-ModuleManifest should update the manifest with correct ReleaseNotes 
     #
     It UpdateModuleManifestWithMultipleLinesReleaseNotes {
-
-        if($PSVersionTable.PSVersion -lt '5.0.0')
-        {            
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion)"
-            return
-        }
-
         $ReleaseNotes = "I'm a test. \nThis is multiple lines.\n\r Try testing"
         New-ModuleManifest -path $script:testManifestPath -ReleaseNotes $ReleaseNotes
         
@@ -838,7 +813,8 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         
         $moduleInfo = Test-ModuleManifest -Path $script:testManifestPath
         AssertEquals $moduleInfo.ReleaseNotes $ReleaseNotes "ReleaseNotes should be $($ReleaseNotes)"
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
     # Purpose: Validate Update-ModuleManifest have proper ReleaseNotes field when there are multiple lines of ReleaseNotes
     #
@@ -847,14 +823,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
 
     # Expected Result: Update-ModuleManifest should update the manifest with correct ReleaseNotes 
     #
-    It UpdateModuleManifestWithMultipleLinesReleaseNotes2 -skip:($env:APPVEYOR_TEST_PASS -eq 'True') {
-
-        if($PSVersionTable.PSVersion -lt '5.0.0')
-        {            
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion)"
-            return
-        }
-
+    It UpdateModuleManifestWithMultipleLinesReleaseNotes2 {
         $ReleaseNotes = @"
         I'm a test.
         This is multiple lines.
@@ -866,7 +835,8 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         
         $moduleInfo = Test-ModuleManifest -Path $script:testManifestPath
         AssertEquals $moduleInfo.ReleaseNotes $ReleaseNotes "ReleaseNotes should be $($ReleaseNotes)"
-    }
+    } `
+    -Skip:$(($PSVersionTable.PSVersion -lt '5.0.0') -and ($env:APPVEYOR_TEST_PASS -eq 'True'))
 
     # Purpose: Validate Update-ModuleManifest cmdlet throw warnings when CompatiblePSEditions is specified for PowerShell version lower than 5.1
     #
@@ -880,7 +850,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         New-ModuleManifest -path $script:testManifestPath
 
         # When running on lower versin of PowerShell
-        if($PSVersionTable.PSVersion -lt [Version]'5.1')
+        if($PSVersionTable.PSVersion -lt '5.1.0')
         {
             AssertFullyQualifiedErrorIdEquals -scriptblock {
                                                                 Update-ModuleManifest -Path $script:testManifestPath `
@@ -909,13 +879,6 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
     # Expected Result: Update-ModuleManifest should update the field "CompatiblePSEditions" in module manifest file.
     #
     It UpdateModuleManifestWithValidCompatiblePSEditions {
-
-        if($PSVersionTable.PSVersion -lt '5.1.0')
-        {            
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion)"
-            return
-        }
-
         New-ModuleManifest -path $script:testManifestPath -PowerShellVersion 5.1 -CompatiblePSEditions 'Desktop'
         $moduleInfo = Test-ModuleManifest -Path $script:testManifestPath
         AssertEquals $moduleInfo.CompatiblePSEditions.Count 1 'CompatiblePSEditions should be Desktop'
@@ -927,5 +890,6 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
 
         Assert ($newModuleInfo.CompatiblePSEditions -contains $CompatiblePSEditions[0]) "CompatiblePSEditions should include $($CompatiblePSEditions[0])"
         Assert ($newModuleInfo.CompatiblePSEditions -contains $CompatiblePSEditions[1]) "CompatiblePSEditions should include $($CompatiblePSEditions[1])"
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.1.0')
 }

--- a/Tests/PSGetUpdateModuleManifest.Tests.ps1
+++ b/Tests/PSGetUpdateModuleManifest.Tests.ps1
@@ -22,7 +22,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
 
     BeforeEach {
         # Create temp moduleManifest to be updated
-        $script:TempModulesPath="$script:TempPath\PSGet_$(Get-Random)"
+        $script:TempModulesPath = Join-Path $script:TempPath "PSGet_$(Get-Random)"
         $null = New-Item -Path $script:TempModulesPath -ItemType Directory -Force
 
         $script:UpdateModuleManifestName = "ContosoPublishModule"
@@ -99,7 +99,8 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         #Make sure the additioanl properties inside PrivateData remain the same
         AssertEquals $newModuleInfo.PrivateData.PackageManagementProviders $oldModuleInfo.PrivateData.PackageManagementProviders "PackageManagement Providers should be $($oldModuleInfo.PrivateData.PackageManagementProviders)"
         AssertEquals $newModuleInfo.PrivateData.SupportedPowerShellGetFormatVersions $oldModuleInfo.PrivateData.SupportedPowerShellGetFormatVersions "SupportedPowerShellGetFormatVersions should be $($oldModuleInfo.PrivateData.SupportedPowerShellGetFormatVersions)"
-    } 
+    } `
+    -Skip:$($IsWindows -eq $False)
 
     # Purpose: Validate Update-ModuleManifest will keep the original property values DefaultCommandPrefix
     #
@@ -246,9 +247,8 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
       
         Assert ($newModuleInfo.Scripts -contains $ScriptsToProcessFilePath) "ScriptsToProcess should include $($ScriptsToProcess)"
         AssertEquals $newModuleInfo.HelpInfoUri $HelpInfoURI "HelpInfoURI should be $($HelpInfoURI)"
-    } 
-
-
+    } `
+    -Skip:$($IsWindows -eq $False)
 
     # Purpose: Update a module manifest with all parameters
     #
@@ -368,8 +368,8 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         AssertEquals $newModuleInfo.HelpInfoUri $HelpInfoURI "HelpInfoURI should be $($HelpInfoURI)"
         Assert ($newModuleInfo.PrivateData.PSData.ExternalModuleDependencies -contains $ExternalModuleDependencies[0]) "ExternalModuleDependencies should include $($ExternalModuleDependencies[0])"
         Assert ($newModuleInfo.PrivateData.PSData.ExternalModuleDependencies -contains $ExternalModuleDependencies[1]) "ExternalModuleDependencies should include $($ExternalModuleDependencies[1])"
-    } 
-
+    } `
+    -Skip:$($IsWindows -eq $False) 
     
     # Purpose: Validate Update-ModuleManifest cmdlet with PrivateData
     #

--- a/Tests/PSGetUpdateScript.Tests.ps1
+++ b/Tests/PSGetUpdateScript.Tests.ps1
@@ -18,9 +18,10 @@ function SuiteSetup {
     Import-Module "$PSScriptRoot\PSGetTestUtils.psm1" -WarningAction SilentlyContinue
     Import-Module "$PSScriptRoot\Asserts.psm1" -WarningAction SilentlyContinue
 
-    $script:MyDocumentsScriptsPath = Join-Path -Path ([Environment]::GetFolderPath("MyDocuments")) -ChildPath "WindowsPowerShell\Scripts"
-    $script:ProgramFilesScriptsPath = Join-Path -Path $env:ProgramFiles -ChildPath "WindowsPowerShell\Scripts"
-    $script:PSGetLocalAppDataPath="$env:LOCALAPPDATA\Microsoft\Windows\PowerShell\PowerShellGet"
+    $script:ProgramFilesScriptsPath = Get-AllUsersScriptsPath 
+    $script:MyDocumentsScriptsPath = Get-CurrentUserScriptsPath 
+    $script:PSGetLocalAppDataPath = Get-PSGetLocalAppDataPath
+    $script:TempPath = Get-TempPath
 
     #Bootstrap NuGet binaries
     Install-NuGetBinaries
@@ -40,11 +41,15 @@ function SuiteSetup {
     Get-InstalledScript -Name Fabrikam-ServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
     Get-InstalledScript -Name Fabrikam-ClientScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
 
-    $script:userName = "PSGetUser"
-    $password = "Password1"
-    $null = net user $script:userName $password /add
-    $secstr = ConvertTo-SecureString $password -AsPlainText -Force
-    $script:credential = new-object -typename System.Management.Automation.PSCredential -argumentlist $script:userName, $secstr
+    if($PSEdition -ne 'Core')
+    {
+        $script:userName = "PSGetUser"
+        $password = "Password1"
+        $null = net user $script:userName $password /add
+        $secstr = ConvertTo-SecureString $password -AsPlainText -Force
+        $script:credential = new-object -typename System.Management.Automation.PSCredential -argumentlist $script:userName, $secstr
+    }
+
     $script:assertTimeOutms = 20000
     
     # Create temp folder for saving the scripts
@@ -68,14 +73,17 @@ function SuiteCleanup {
     # Import the PowerShellGet provider to reload the repositories.
     $null = Import-PackageProvider -Name PowerShellGet -Force
 
-    # Delete the user
-    net user $script:UserName /delete | Out-Null
-    # Delete the user profile
-    $userProfile = (Get-WmiObject -Class Win32_UserProfile | Where-Object {$_.LocalPath -match $script:UserName})
-	if($userProfile)
-	{
-		RemoveItem $userProfile.LocalPath
-	}
+    if($PSEdition -ne 'Core')
+    {
+        # Delete the user
+        net user $script:UserName /delete | Out-Null
+        # Delete the user profile
+        $userProfile = (Get-WmiObject -Class Win32_UserProfile | Where-Object {$_.LocalPath -match $script:UserName})
+        if($userProfile)
+        {
+            RemoveItem $userProfile.LocalPath
+        }
+    }
     RemoveItem $script:TempSavePath
 
 
@@ -112,16 +120,9 @@ Describe PowerShell.PSGet.UpdateScriptTests -Tags 'BVT','InnerLoop' {
     # Expected Result: script should not be updated after confirming NO
     #
     It "UpdateScriptWithConfirmAndNoToPrompt" {
-
-        if(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
-        {            
-            Write-Warning -Message "Skipped on OSVersion: $([System.Environment]::OSVersion.Version) with PSCulture: $PSCulture"
-            return
-        }
-
         $installedVersion = "1.0"
         Install-Script Fabrikam-ServerScript -RequiredVersion $installedVersion
-        $outputPath = $env:temp
+        $outputPath = $script:TempPath
         $guid =  [system.guid]::newguid().tostring()
         $outputFilePath = Join-Path $outputPath "$guid"
         $runspace = CreateRunSpace $outputFilePath 1
@@ -155,7 +156,8 @@ Describe PowerShell.PSGet.UpdateScriptTests -Tags 'BVT','InnerLoop' {
         $res = Get-InstalledScript Fabrikam-ServerScript
         AssertEquals $res.Name 'Fabrikam-ServerScript' "Update-Script should not update the Fabrikam-ServerScript script when pressed NO to Confirm."
         AssertEquals $res.Version $installedVersion "Update-Script should not update the Fabrikam-ServerScript script when pressed NO to Confirm."
-    }
+    } `
+    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
 
     # Purpose: UpdateScriptWithConfirmAndYesToPrompt
     #
@@ -164,16 +166,9 @@ Describe PowerShell.PSGet.UpdateScriptTests -Tags 'BVT','InnerLoop' {
     # Expected Result: script should be updated after confirming YES
     #
     It "UpdateScriptWithConfirmAndYesToPrompt" {
-        
-        if(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
-        {            
-            Write-Warning -Message "Skipped on OSVersion: $([System.Environment]::OSVersion.Version) with PSCulture: $PSCulture"
-            return
-        }
-
         $installedVersion = '1.0'
         Install-Script Fabrikam-ServerScript -RequiredVersion $installedVersion
-        $outputPath = $env:temp
+        $outputPath = $script:TempPath
         $guid =  [system.guid]::newguid().tostring()
         $outputFilePath = Join-Path $outputPath "$guid"
         $runspace = CreateRunSpace $outputFilePath 1
@@ -207,7 +202,8 @@ Describe PowerShell.PSGet.UpdateScriptTests -Tags 'BVT','InnerLoop' {
         $res = Get-InstalledScript Fabrikam-ServerScript
         AssertEquals $res.Name 'Fabrikam-ServerScript' "Update-Script should not update the Fabrikam-ServerScript script when pressed NO to Confirm, $res"
         Assert ($res.Version -gt [Version]"1.0") "Update-Script should not update the Fabrikam-ServerScript script when pressed NO to Confirm, $res"
-    }
+    } `
+    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
 
     # Purpose: UpdateScriptWithWhatIf
     #
@@ -216,17 +212,10 @@ Describe PowerShell.PSGet.UpdateScriptTests -Tags 'BVT','InnerLoop' {
     # Expected Result: script should not be updated -WhatIf
     #
     It "UpdateScriptWithWhatIf" {
-
-        if(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US'))
-        {            
-            Write-Warning -Message "Skipped on OSVersion: $([System.Environment]::OSVersion.Version) with PSCulture: $PSCulture"
-            return
-        }
-
         $installedVersion = "1.0"
         Install-Script Fabrikam-ServerScript -RequiredVersion $installedVersion
 
-        $outputPath = $env:temp
+        $outputPath = $script:TempPath
         $guid =  [system.guid]::newguid().tostring()
         $outputFilePath = Join-Path $outputPath "$guid"
         $runspace = CreateRunSpace $outputFilePath 1
@@ -257,7 +246,8 @@ Describe PowerShell.PSGet.UpdateScriptTests -Tags 'BVT','InnerLoop' {
         $res = Get-InstalledScript Fabrikam-ServerScript
         AssertEquals $res.Name 'Fabrikam-ServerScript' "Update-Script should not update the script with -WhatIf option, $res"
         Assert ($res.Version -eq [Version]"1.0") "Update-Script should not update the script with -WhatIf option, $res"
-    }
+    } `
+    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
 
     # Purpose: UpdateScriptWithFalseConfirm
     #
@@ -428,18 +418,6 @@ Describe PowerShell.PSGet.UpdateScriptTests -Tags 'BVT','InnerLoop' {
     # Expected Result: should fail with an error
     #
     It "AdminPrivilegesAreRequiredForUpdatingAllUsersScript" {
-
-        $whoamiValue = (whoami)
-
-        if( ($whoamiValue -eq "NT AUTHORITY\SYSTEM") -or
-            ($whoamiValue -eq "NT AUTHORITY\LOCAL SERVICE") -or
-            ($whoamiValue -eq "NT AUTHORITY\NETWORK SERVICE") -or
-            ($PSVersionTable.PSVersion -lt [Version]"4.0") )
-        {
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion) for user $whoamiValue"
-            return
-        }
-
         Install-Script -Name Fabrikam-ServerScript -RequiredVersion 1.0 -Scope AllUsers
         $NonAdminConsoleOutput = Join-Path $TestDrive 'nonadminconsole-out.txt'
         Start-Process "$PSHOME\PowerShell.exe" -ArgumentList '$null = Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Scope CurrentUser;
@@ -454,7 +432,16 @@ Describe PowerShell.PSGet.UpdateScriptTests -Tags 'BVT','InnerLoop' {
         $content = Get-Content $NonAdminConsoleOutput
         Assert ($content -match 'AdminPrivilegesAreRequiredForUpdate') "Update-Script should fail when non-admin user is trying to update a script installed to allusers scope, $content"
         RemoveItem $NonAdminConsoleOutput
-    }
+    } `
+    -Skip:$(
+        $whoamiValue = (whoami)
+
+        ($whoamiValue -eq "NT AUTHORITY\SYSTEM") -or
+        ($whoamiValue -eq "NT AUTHORITY\LOCAL SERVICE") -or
+        ($whoamiValue -eq "NT AUTHORITY\NETWORK SERVICE") -or
+        ($PSEdition -eq 'Core') -or
+        ($PSVersionTable.PSVersion -lt '4.0.0') 
+    )
 
     # Purpose: UpdateScriptWithLowerReqVersionShouldNotUpdate
     #
@@ -579,13 +566,6 @@ Describe PowerShell.PSGet.UpdateScriptTests -Tags 'P1','OuterLoop' {
     # Expected Result: Should update the script along with its dependencies
     #
     It UpdateScriptWithIncludeDependencies {
-
-        if($PSVersionTable.PSVersion -lt '5.0.0')
-        {            
-            Write-Warning -Message "Skipped on PSVersion: $($PSVersionTable.PSVersion)"
-            return
-        }
-
         $ScriptName = 'Script-WithDependencies2'
         $NamesToUninstall = @()
 
@@ -635,5 +615,5 @@ Describe PowerShell.PSGet.UpdateScriptTests -Tags 'P1','OuterLoop' {
                                     PowerShellGet\Uninstall-Module $_ -Force -ErrorAction SilentlyContinue
                                 }
         }
-    }    
+    }  -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')  
 }

--- a/Tests/PSGetUpdateScript.Tests.ps1
+++ b/Tests/PSGetUpdateScript.Tests.ps1
@@ -157,7 +157,7 @@ Describe PowerShell.PSGet.UpdateScriptTests -Tags 'BVT','InnerLoop' {
         AssertEquals $res.Name 'Fabrikam-ServerScript' "Update-Script should not update the Fabrikam-ServerScript script when pressed NO to Confirm."
         AssertEquals $res.Version $installedVersion "Update-Script should not update the Fabrikam-ServerScript script when pressed NO to Confirm."
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ($PSCulture -ne 'en-US') -or ([System.Environment]::OSVersion.Version -lt '6.2.9200.0'))
 
     # Purpose: UpdateScriptWithConfirmAndYesToPrompt
     #
@@ -203,7 +203,7 @@ Describe PowerShell.PSGet.UpdateScriptTests -Tags 'BVT','InnerLoop' {
         AssertEquals $res.Name 'Fabrikam-ServerScript' "Update-Script should not update the Fabrikam-ServerScript script when pressed NO to Confirm, $res"
         Assert ($res.Version -gt [Version]"1.0") "Update-Script should not update the Fabrikam-ServerScript script when pressed NO to Confirm, $res"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ($PSCulture -ne 'en-US') -or ([System.Environment]::OSVersion.Version -lt '6.2.9200.0'))
 
     # Purpose: UpdateScriptWithWhatIf
     #
@@ -247,7 +247,7 @@ Describe PowerShell.PSGet.UpdateScriptTests -Tags 'BVT','InnerLoop' {
         AssertEquals $res.Name 'Fabrikam-ServerScript' "Update-Script should not update the script with -WhatIf option, $res"
         Assert ($res.Version -eq [Version]"1.0") "Update-Script should not update the script with -WhatIf option, $res"
     } `
-    -Skip:$(([System.Environment]::OSVersion.Version -lt "6.2.9200.0") -or ($PSCulture -ne 'en-US') -or ($PSEdition -eq 'Core'))
+    -Skip:$(($PSEdition -eq 'Core') -or ($PSCulture -ne 'en-US') -or ([System.Environment]::OSVersion.Version -lt '6.2.9200.0'))
 
     # Purpose: UpdateScriptWithFalseConfirm
     #

--- a/Tests/PSGetUpdateScript.Tests.ps1
+++ b/Tests/PSGetUpdateScript.Tests.ps1
@@ -439,6 +439,7 @@ Describe PowerShell.PSGet.UpdateScriptTests -Tags 'BVT','InnerLoop' {
         ($whoamiValue -eq "NT AUTHORITY\SYSTEM") -or
         ($whoamiValue -eq "NT AUTHORITY\LOCAL SERVICE") -or
         ($whoamiValue -eq "NT AUTHORITY\NETWORK SERVICE") -or
+        ($env:APPVEYOR_TEST_PASS -eq 'True') -or
         ($PSEdition -eq 'Core') -or
         ($PSVersionTable.PSVersion -lt '4.0.0') 
     )

--- a/Tests/PSGetUpdateScript.Tests.ps1
+++ b/Tests/PSGetUpdateScript.Tests.ps1
@@ -544,7 +544,7 @@ Describe PowerShell.PSGet.UpdateScriptTests -Tags 'BVT','InnerLoop' {
     }
 }
 
-Describe PowerShell.PSGet.UpdateScriptTests -Tags 'P1','OuterLoop' {
+Describe PowerShell.PSGet.UpdateScriptTests.P1 -Tags 'P1','OuterLoop' {
 
     BeforeAll {
         SuiteSetup

--- a/Tests/Pester.CatalogSignedModules.Tests.ps1
+++ b/Tests/Pester.CatalogSignedModules.Tests.ps1
@@ -2,6 +2,10 @@
 #
 # Copyright (c) Microsoft Corporation, 2016
 
+if($IsWindows -eq $false) {
+    return
+}
+
 Import-Module "$PSScriptRoot\PSGetTestUtils.psm1" -WarningAction SilentlyContinue
 
 $Script:RepositoryName = 'Local'

--- a/Tests/Pester.PSRepository.Tests.ps1
+++ b/Tests/Pester.PSRepository.Tests.ps1
@@ -53,18 +53,18 @@ Describe 'Test Register-PSRepository and Register-PackageSource for PSGallery re
     }
 
     It 'Reregister PSGallery again: Should fail' {
-        if($PSVersionTable.PSVersion -lt '5.0.0') { Write-Warning "Skipped on $($PSVersionTable.PSVersion)"; return }
         Register-PSRepository -Default
         Register-PSRepository -Default -ErrorVariable ev -ErrorAction SilentlyContinue
         $ev[0].FullyQualifiedErrorId | Should be 'PackageSourceExists,Microsoft.PowerShell.PackageManagement.Cmdlets.RegisterPackageSource'
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
     It 'Register-PSRepository -Default:$false : Should not register' {
-        if($PSVersionTable.PSVersion -lt '5.0.0') { Write-Warning "Skipped on $($PSVersionTable.PSVersion)"; return }
         Register-PSRepository -Default:$false
         Get-PSRepository PSGallery -ErrorVariable ev -ErrorAction SilentlyContinue
         $ev[0].FullyQualifiedErrorId | Should be 'SourceNotFound,Microsoft.PowerShell.PackageManagement.Cmdlets.GetPackageSource'
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
     It 'Register-PSRepository -Name PSGallery -SourceLocation $SourceLocation : Should fail' {
         { Register-PSRepository $RepositoryName $SourceLocation -ErrorVariable ev -ErrorAction SilentlyContinue } | Should Throw
@@ -97,28 +97,28 @@ Describe 'Test Register-PSRepository and Register-PackageSource for PSGallery re
     }
 
     It 'Register-PackageSource -ProviderName PowerShellGet -Name PSGallery -Location $SourceLocation : Should fail' {
-        if($PSVersionTable.PSVersion -lt '5.0.0') { Write-Warning "Skipped on $($PSVersionTable.PSVersion)"; return }
         Register-PackageSource -ProviderName PowerShellGet -Name $RepositoryName -Location $SourceLocation -ErrorVariable ev -ErrorAction SilentlyContinue
         $ev[0].FullyQualifiedErrorId | Should be 'ParameterIsNotAllowedWithPSGallery,Add-PackageSource,Microsoft.PowerShell.PackageManagement.Cmdlets.RegisterPackageSource'
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
     
     It 'Register-PackageSource -ProviderName PowerShellGet -Name PSGallery -PublishLocation $PublishLocation : Should fail' {
-        if($PSVersionTable.PSVersion -lt '5.0.0') { Write-Warning "Skipped on $($PSVersionTable.PSVersion)"; return }
         Register-PackageSource -ProviderName PowerShellGet -Name $RepositoryName -PublishLocation $PublishLocation -ErrorVariable ev -ErrorAction SilentlyContinue
         $ev[0].FullyQualifiedErrorId | Should be 'ParameterIsNotAllowedWithPSGallery,Add-PackageSource,Microsoft.PowerShell.PackageManagement.Cmdlets.RegisterPackageSource'
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
     It 'Register-PackageSource -ProviderName PowerShellGet -Name PSGallery -ScriptPublishLocation $ScriptPublishLocation : should fail' {
-        if($PSVersionTable.PSVersion -lt '5.0.0') { Write-Warning "Skipped on $($PSVersionTable.PSVersion)"; return }
         Register-PackageSource -ProviderName PowerShellGet -Name $RepositoryName -ScriptPublishLocation $ScriptPublishLocation -ErrorVariable ev -ErrorAction SilentlyContinue
         $ev[0].FullyQualifiedErrorId | Should be 'ParameterIsNotAllowedWithPSGallery,Add-PackageSource,Microsoft.PowerShell.PackageManagement.Cmdlets.RegisterPackageSource'
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
     It 'Register-PackageSource -ProviderName PowerShellGet -Name PSGallery -ScriptSourceLocation $ScriptSourceLocation : should fail' {
-        if($PSVersionTable.PSVersion -lt '5.0.0') { Write-Warning "Skipped on $($PSVersionTable.PSVersion)"; return }
         Register-PackageSource -ProviderName PowerShellGet -Name PSGallery -ScriptSourceLocation $ScriptSourceLocation -ErrorVariable ev -ErrorAction SilentlyContinue
         $ev[0].FullyQualifiedErrorId | Should be 'ParameterIsNotAllowedWithPSGallery,Add-PackageSource,Microsoft.PowerShell.PackageManagement.Cmdlets.RegisterPackageSource'
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 }
 
 Describe 'Test Set-PSRepository and Set-PackageSource for PSGallery repository' -tags 'BVT','InnerLoop' {
@@ -165,28 +165,28 @@ Describe 'Test Set-PSRepository and Set-PackageSource for PSGallery repository' 
     }
 
     It 'Set-PSRepository -Name PSGallery -SourceLocation $SourceLocation : should fail' {
-        if($PSVersionTable.PSVersion -lt '5.0.0') { Write-Warning "Skipped on $($PSVersionTable.PSVersion)"; return }
         Set-PSRepository $RepositoryName $SourceLocation -ErrorVariable ev -ErrorAction SilentlyContinue
         $ev[0].FullyQualifiedErrorId | Should be 'ParameterIsNotAllowedWithPSGallery,Add-PackageSource,Microsoft.PowerShell.PackageManagement.Cmdlets.SetPackageSource'
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
     It 'Set-PSRepository -Name PSGallery -PublishLocation $PublishLocation : should fail' {
-        if($PSVersionTable.PSVersion -lt '5.0.0') { Write-Warning "Skipped on $($PSVersionTable.PSVersion)"; return }
         Set-PSRepository $RepositoryName -PublishLocation $PublishLocation -ErrorVariable ev -ErrorAction SilentlyContinue
         $ev[0].FullyQualifiedErrorId | Should be 'ParameterIsNotAllowedWithPSGallery,Add-PackageSource,Microsoft.PowerShell.PackageManagement.Cmdlets.SetPackageSource'
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
     It 'Set-PSRepository -Name PSGallery -ScriptPublishLocation $ScriptPublishLocation : should fail' {
-        if($PSVersionTable.PSVersion -lt '5.0.0') { Write-Warning "Skipped on $($PSVersionTable.PSVersion)"; return }
         Set-PSRepository $RepositoryName -ScriptPublishLocation $ScriptPublishLocation -ErrorVariable ev -ErrorAction SilentlyContinue
         $ev[0].FullyQualifiedErrorId | Should be 'ParameterIsNotAllowedWithPSGallery,Add-PackageSource,Microsoft.PowerShell.PackageManagement.Cmdlets.SetPackageSource'
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
     It 'Set-PSRepository -Name PSGallery -ScriptSourceLocation $ScriptSourceLocation : should fail' {
-        if($PSVersionTable.PSVersion -lt '5.0.0') { Write-Warning "Skipped on $($PSVersionTable.PSVersion)"; return }
         Set-PSRepository -Name $RepositoryName -ScriptSourceLocation $ScriptSourceLocation -ErrorVariable ev -ErrorAction SilentlyContinue
         $ev[0].FullyQualifiedErrorId | Should be 'ParameterIsNotAllowedWithPSGallery,Add-PackageSource,Microsoft.PowerShell.PackageManagement.Cmdlets.SetPackageSource'
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
     It 'Set-PackageSource -ProviderName PowerShellGet -Name PSGallery : should work actually this is a no-op. Installation policy should not be changed' {
         Set-PackageSource -ProviderName PowerShellGet -Name $RepositoryName
@@ -203,26 +203,26 @@ Describe 'Test Set-PSRepository and Set-PackageSource for PSGallery repository' 
     }
 
     It 'Set-PackageSource -ProviderName PowerShellGet -Name PSGallery -SourceLocation $SourceLocation : should fail' {
-        if($PSVersionTable.PSVersion -lt '5.0.0') { Write-Warning "Skipped on $($PSVersionTable.PSVersion)"; return }
         Set-PackageSource -ProviderName PowerShellGet -Name $RepositoryName -NewLocation $SourceLocation -ErrorVariable ev -ErrorAction SilentlyContinue
         $ev[0].FullyQualifiedErrorId | Should be 'ParameterIsNotAllowedWithPSGallery,Add-PackageSource,Microsoft.PowerShell.PackageManagement.Cmdlets.SetPackageSource'
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
     It 'Set-PackageSource -ProviderName PowerShellGet -Name PSGallery -PublishLocation $PublishLocation : should fail' {
-        if($PSVersionTable.PSVersion -lt '5.0.0') { Write-Warning "Skipped on $($PSVersionTable.PSVersion)"; return }
         Set-PackageSource -ProviderName PowerShellGet -Name $RepositoryName -PublishLocation $PublishLocation -ErrorVariable ev -ErrorAction SilentlyContinue
         $ev[0].FullyQualifiedErrorId | Should be 'ParameterIsNotAllowedWithPSGallery,Add-PackageSource,Microsoft.PowerShell.PackageManagement.Cmdlets.SetPackageSource'
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
     It 'Set-PackageSource -ProviderName PowerShellGet -Name PSGallery -ScriptPublishLocation $ScriptPublishLocation : should fail' {
-        if($PSVersionTable.PSVersion -lt '5.0.0') { Write-Warning "Skipped on $($PSVersionTable.PSVersion)"; return }
         Set-PackageSource -ProviderName PowerShellGet -Name $RepositoryName -ScriptPublishLocation $ScriptPublishLocation -ErrorVariable ev -ErrorAction SilentlyContinue
         $ev[0].FullyQualifiedErrorId | Should be 'ParameterIsNotAllowedWithPSGallery,Add-PackageSource,Microsoft.PowerShell.PackageManagement.Cmdlets.SetPackageSource'
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
     It 'Set-PackageSource -ProviderName PowerShellGet -Name PSGallery -ScriptSourceLocation $ScriptSourceLocation : should fail' {
-        if($PSVersionTable.PSVersion -lt '5.0.0') { Write-Warning "Skipped on $($PSVersionTable.PSVersion)"; return }
         Set-PackageSource -ProviderName PowerShellGet -Name $RepositoryName -ScriptSourceLocation $ScriptSourceLocation -ErrorVariable ev -ErrorAction SilentlyContinue
         $ev[0].FullyQualifiedErrorId | Should be 'ParameterIsNotAllowedWithPSGallery,Add-PackageSource,Microsoft.PowerShell.PackageManagement.Cmdlets.SetPackageSource'
-    }
+    } `
+    -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 }

--- a/Tests/uiproxy.ps1
+++ b/Tests/uiproxy.ps1
@@ -1,5 +1,11 @@
 #param($command)
 
+if($PSEdition -eq 'Core')
+{
+    Write-Verbose 'uiProxy is not supported on PowerShell Core Edition'
+    return
+}
+
 $source = @"
 using System;
 using System.Collections.Generic;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,4 +55,3 @@ on_finish:
             # You can add other artifacts here
             (ls $zipFile)
         ) | % { Push-AppveyorArtifact $_.FullName }
-        $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,8 @@ environment:
     matrix: 
     - PowerShellEdition: Desktop 
     - PowerShellEdition: Core
+configuration: Release
+platform: Any CPU
 
 # clone directory
 clone_folder: c:\projects\powershellget
@@ -15,7 +17,6 @@ init:
 # Install Pester and PackageManagement modules
 install:
     - ps: | 
-        $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
         Import-Module .\tools\build.psm1
         Install-Dependencies
 
@@ -35,7 +36,6 @@ branches:
 # Run Pester tests and store the results
 test_script:
     - ps: |
-        $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
         Import-Module .\tools\build.psm1
         Invoke-PowerShellGetTest
         $TestResultFilePath = Resolve-Path .\Tests\TestResults.xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,3 +55,4 @@ on_finish:
             # You can add other artifacts here
             (ls $zipFile)
         ) | % { Push-AppveyorArtifact $_.FullName }
+        $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,11 @@
 os:
     - "WMF 5"
 
+environment: 
+    matrix: 
+    - PowerShellEdition: Desktop 
+    - PowerShellEdition: Core
+
 # clone directory
 clone_folder: c:\projects\powershellget
 
@@ -10,27 +15,8 @@ init:
 # Install Pester and PackageManagement modules
 install:
     - ps: | 
-        nuget install pester -source https://www.powershellgallery.com/api/v2 -outputDirectory "$Env:ProgramFiles\WindowsPowerShell\Modules\." -ExcludeVersion
-        
-        # Install latest PackageManagement module from PSGallery
-        $TempModulePath = Microsoft.PowerShell.Management\Join-Path -Path $env:TEMP -ChildPath "$(Get-Random)"
-        $null = Microsoft.PowerShell.Management\New-Item -Path $TempModulePath -Force -ItemType Directory
-        $OneGetModuleName = 'PackageManagement'
-        try
-        {
-            nuget install $OneGetModuleName -source https://dtlgalleryint.cloudapp.net/api/v2 -outputDirectory $TempModulePath -verbosity detailed
-            $OneGetWithVersion = Microsoft.PowerShell.Management\Get-ChildItem -Path $TempModulePath -Directory
-            $OneGetVersion = ($OneGetWithVersion.Name.Split('.',2))[1]
-            $OneGetProgramFilesPath = "$Env:ProgramFiles\WindowsPowerShell\Modules\$OneGetModuleName\$OneGetVersion"
-            $null = Microsoft.PowerShell.Management\New-Item -Path $OneGetProgramFilesPath -Force -ItemType Directory
-            Microsoft.PowerShell.Management\Copy-Item -Path "$($OneGetWithVersion.FullName)\*" -Destination "$OneGetProgramFilesPath\" -Recurse -Force -Verbose
-            Get-Module -ListAvailable -Name $OneGetModuleName | Microsoft.PowerShell.Core\Where-Object {$_.Version -eq $OneGetVersion}
-        }
-        finally
-        {
-            Remove-Item -Path $TempModulePath -Recurse -Force
-        }
-
+        Import-Module .\tools\build.psm1
+        Install-Dependencies
 
 # to run your custom scripts instead of automatic MSBuild
 #build_script:
@@ -48,46 +34,13 @@ branches:
 # Run Pester tests and store the results
 test_script:
     - ps: |
-        $ModuleVersion = '1.1.2.0'
-        $InstallLocation = "$Env:ProgramFiles\WindowsPowerShell\Modules\PowerShellGet"
-        if($PSVersionTable.PSVersion -ge '5.0.0')
-        {
-            $InstallLocation = Join-Path -Path $InstallLocation -ChildPath $ModuleVersion
+        Import-Module .\tools\build.psm1
+        Invoke-PowerShellGetTest
+        $TestResultFilePath = Resolve-Path .\Tests\TestResults.xml
+        if(Microsoft.PowerShell.Management\Test-Path -Path $TestResultFilePath -PathType Leaf) {
+            (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", $TestResultFilePath)
         }
-        $null = New-Item -Path $InstallLocation -ItemType Directory -Force
-        copy "C:\projects\powershellget\powershellget\*" $InstallLocation -Recurse -Force -Verbose
 
-        "env:PSModulePath value $($env:PSModulePath)"
-        "PSVersionTable value $($PSVersionTable | Out-String)"
-
-        # Download the NuGet.exe from http://nuget.org/NuGet.exe
-        $PSGetProgramDataPath = "$env:LOCALAPPDATA\Microsoft\Windows\PowerShell\PowerShellGet"
-        $NuGetExeName = 'NuGet.exe'
-        if(-not (Microsoft.PowerShell.Management\Test-Path -Path $PSGetProgramDataPath))
-        {
-            $null = Microsoft.PowerShell.Management\New-Item -Path $PSGetProgramDataPath -ItemType Directory -Force
-        }
-        $NugetExeFilePath = Microsoft.PowerShell.Management\Join-Path -Path $PSGetProgramDataPath -ChildPath $NuGetExeName
-        Microsoft.PowerShell.Utility\Invoke-WebRequest -Uri http://nuget.org/NuGet.exe -OutFile $NugetExeFilePath
-        Get-ChildItem $NugetExeFilePath -File
-
-        Get-PSRepository
-        Get-PackageProvider
-        Get-Module
-
-        $env:APPVEYOR_TEST_PASS = $true
-        Push-Location C:\projects\powershellget\Tests\
-        try {
-            $TestResultsFile = ".\TestResults.xml"
-            $TestResults = Invoke-Pester -Script "C:\projects\powershellget\Tests\" -OutputFormat NUnitXml -OutputFile $TestResultsFile -PassThru -Tag BVT  
-            (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $TestResultsFile))
-            if ($TestResults.FailedCount -gt 0) {
-                throw "$($TestResults.FailedCount) tests failed."
-            }
-        }
-        finally {
-            Pop-Location
-        }
 
 # Upload the project along with TestResults as a zip archive
 on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ init:
 # Install Pester and PackageManagement modules
 install:
     - ps: | 
+        $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
         Import-Module .\tools\build.psm1
         Install-Dependencies
 
@@ -34,6 +35,7 @@ branches:
 # Run Pester tests and store the results
 test_script:
     - ps: |
+        $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
         Import-Module .\tools\build.psm1
         Invoke-PowerShellGetTest
         $TestResultFilePath = Resolve-Path .\Tests\TestResults.xml

--- a/tools/build.psm1
+++ b/tools/build.psm1
@@ -67,13 +67,6 @@ function Install-Dependencies {
         }
 
         $AllUsersModulesPath = $script:ProgramFilesModulesPath
-        <# TODO: Install latest version of OneGet on PSCore
-        if(($script:PowerShellEdition -eq 'Core') -and $script:IsWindows)
-        {
-            $AllUsersModulesPath = Microsoft.PowerShell.Management\Join-Path -Path (Get-PSHome) -ChildPath 'Modules'
-        }
-        #>
-
         # Install latest PackageManagement module from PSGallery
         $TempModulePath = Microsoft.PowerShell.Management\Join-Path -Path $script:TempPath -ChildPath "$(Get-Random)"
         $null = Microsoft.PowerShell.Management\New-Item -Path $TempModulePath -Force -ItemType Directory

--- a/tools/build.psm1
+++ b/tools/build.psm1
@@ -136,7 +136,11 @@ function Invoke-PowerShellGetTest {
     $ClonedProjectPath = Resolve-Path "$PSScriptRoot\.."    
     $PowerShellGetTestsPath = "$ClonedProjectPath\Tests\"
     $PowerShellHome = Get-PSHome
-    $PowerShellExePath = "$PowerShellHome\PowerShell.exe"
+    if($script:IsWindows){
+        $PowerShellExePath = Join-Path -Path $PowerShellHome -ChildPath 'PowerShell.exe'
+    } else {
+        $PowerShellExePath = 'powershell'
+    }
 
     $AllUsersModulesPath = $script:ProgramFilesModulesPath
     if(($script:PowerShellEdition -eq 'Core') -and $script:IsWindows)
@@ -146,7 +150,7 @@ function Invoke-PowerShellGetTest {
 
     # Copy OneGet and PSGet modules to PSHOME    
     $PowerShellGetSourcePath = Microsoft.PowerShell.Management\Join-Path -Path $ClonedProjectPath -ChildPath $script:PowerShellGet
-    $PowerShellGetModuleInfo = Test-ModuleManifest "$PowerShellGetSourcePath\PowerShellGet.psd1"
+    $PowerShellGetModuleInfo = Test-ModuleManifest "$PowerShellGetSourcePath\PowerShellGet.psd1" -ErrorAction Ignore
     $ModuleVersion = "$($PowerShellGetModuleInfo.Version)"
 
     $InstallLocation =  Microsoft.PowerShell.Management\Join-Path -Path $AllUsersModulesPath -ChildPath 'PowerShellGet'
@@ -162,7 +166,7 @@ function Invoke-PowerShellGetTest {
         $env:PSModulePath;
         $PSVersionTable;
         Get-PackageProvider;
-        Get-PSRepository -Verbose;
+        Get-PSRepository;
         Get-Module;
 '@
 

--- a/tools/build.psm1
+++ b/tools/build.psm1
@@ -1,0 +1,190 @@
+$script:PowerShellGet = 'PowerShellGet'
+$script:IsInbox = $PSHOME.EndsWith('\WindowsPowerShell\v1.0', [System.StringComparison]::OrdinalIgnoreCase)
+$script:IsWindows = (-not (Get-Variable -Name IsWindows -ErrorAction Ignore)) -or $IsWindows
+$script:IsLinux = (Get-Variable -Name IsLinux -ErrorAction Ignore) -and $IsLinux
+$script:IsOSX = (Get-Variable -Name IsOSX -ErrorAction Ignore) -and $IsOSX
+$script:IsCoreCLR = (Get-Variable -Name IsCoreCLR -ErrorAction Ignore) -and $IsCoreCLR
+
+if($script:IsInbox) {
+    $script:ProgramFilesPSPath = Microsoft.PowerShell.Management\Join-Path -Path $env:ProgramFiles -ChildPath "WindowsPowerShell"
+} else {
+    $script:ProgramFilesPSPath = $PSHome
+}
+
+if($script:IsInbox) {
+    try {
+        $script:MyDocumentsFolderPath = [Environment]::GetFolderPath("MyDocuments")
+    } catch {
+        $script:MyDocumentsFolderPath = $null
+    }
+
+    $script:MyDocumentsPSPath = if($script:MyDocumentsFolderPath) {
+                                    Microsoft.PowerShell.Management\Join-Path -Path $script:MyDocumentsFolderPath -ChildPath "WindowsPowerShell"
+                                } else {
+                                    Microsoft.PowerShell.Management\Join-Path -Path $env:USERPROFILE -ChildPath "Documents\WindowsPowerShell"
+                                }
+} elseif($script:IsWindows) {
+    $script:MyDocumentsPSPath = Microsoft.PowerShell.Management\Join-Path -Path $HOME -ChildPath 'Documents\PowerShell'
+} else {
+    $script:MyDocumentsPSPath = Microsoft.PowerShell.Management\Join-Path -Path $HOME -ChildPath ".local/share/powershell"
+}
+
+$script:ProgramFilesModulesPath = Microsoft.PowerShell.Management\Join-Path -Path $script:ProgramFilesPSPath -ChildPath "Modules"
+$script:MyDocumentsModulesPath = Microsoft.PowerShell.Management\Join-Path -Path $script:MyDocumentsPSPath -ChildPath "Modules"
+$script:ProgramFilesScriptsPath = Microsoft.PowerShell.Management\Join-Path -Path $script:ProgramFilesPSPath -ChildPath "Scripts"
+$script:MyDocumentsScriptsPath = Microsoft.PowerShell.Management\Join-Path -Path $script:MyDocumentsPSPath -ChildPath "Scripts"
+$script:TempPath = if($script:IsWindows) { ([System.IO.DirectoryInfo]$env:TEMP).FullName } else { '/tmp' }
+
+if($script:IsWindows) {
+    $script:PSGetProgramDataPath = Microsoft.PowerShell.Management\Join-Path -Path $env:ProgramData -ChildPath 'Microsoft\Windows\PowerShell\PowerShellGet\'
+    $script:PSGetAppLocalPath = Microsoft.PowerShell.Management\Join-Path -Path $env:LOCALAPPDATA -ChildPath 'Microsoft\Windows\PowerShell\PowerShellGet\'
+} else {
+    $script:PSGetProgramDataPath = "$HOME/.config/powershell/powershellget"
+    $script:PSGetAppLocalPath = "$HOME/.config/powershell/powershellget"
+}
+
+function Install-Dependencies {
+    if($env:PowerShellEdition -eq 'Desktop') {
+        # Download the NuGet.exe from http://nuget.org/NuGet.exe
+        $NuGetExeName = 'NuGet.exe'
+        if(-not (Microsoft.PowerShell.Management\Test-Path -Path $script:PSGetProgramDataPath))
+        {
+            $null = Microsoft.PowerShell.Management\New-Item -Path $script:PSGetProgramDataPath -ItemType Directory -Force
+        }
+        $NugetExeFilePath = Microsoft.PowerShell.Management\Join-Path -Path $script:PSGetProgramDataPath -ChildPath $NuGetExeName
+        Microsoft.PowerShell.Utility\Invoke-WebRequest -Uri http://nuget.org/NuGet.exe -OutFile $NugetExeFilePath
+        Get-ChildItem $NugetExeFilePath -File
+        
+        if(-not (Get-Module -ListAvailable Pester))
+        {
+            nuget install pester -source https://www.powershellgallery.com/api/v2 -outputDirectory $script:ProgramFilesModulesPath -ExcludeVersion
+        }
+
+        $AllUsersModulesPath = $script:ProgramFilesModulesPath
+        <# TODO: Install latest version of OneGet on PSCore
+        if(($env:PowerShellEdition -eq 'Core') -and $script:IsWindows)
+        {
+            $AllUsersModulesPath = Microsoft.PowerShell.Management\Join-Path -Path (Get-PSHome) -ChildPath 'Modules'
+        }
+        #>
+
+        # Install latest PackageManagement module from PSGallery
+        $TempModulePath = Microsoft.PowerShell.Management\Join-Path -Path $script:TempPath -ChildPath "$(Get-Random)"
+        $null = Microsoft.PowerShell.Management\New-Item -Path $TempModulePath -Force -ItemType Directory
+        $OneGetModuleName = 'PackageManagement'
+        try
+        {
+            nuget install $OneGetModuleName -source https://dtlgalleryint.cloudapp.net/api/v2 -outputDirectory $TempModulePath -verbosity detailed
+            $OneGetWithVersion = Microsoft.PowerShell.Management\Get-ChildItem -Path $TempModulePath -Directory
+            $OneGetVersion = ($OneGetWithVersion.Name.Split('.',2))[1]
+
+            $OneGetModulePath = Microsoft.PowerShell.Management\Join-Path -Path  $AllUsersModulesPath -ChildPath $OneGetModuleName        
+            if($PSVersionTable.PSVersion -ge '5.0.0')
+            {
+                $OneGetModulePath = Microsoft.PowerShell.Management\Join-Path -Path $OneGetModulePath -ChildPath $OneGetVersion
+            }
+
+            $null = Microsoft.PowerShell.Management\New-Item -Path $OneGetModulePath -Force -ItemType Directory
+            Microsoft.PowerShell.Management\Copy-Item -Path "$($OneGetWithVersion.FullName)\*" -Destination "$OneGetModulePath\" -Recurse -Force
+            Get-Module -ListAvailable -Name $OneGetModuleName | Microsoft.PowerShell.Core\Where-Object {$_.Version -eq $OneGetVersion}
+        }
+        finally
+        {
+            Remove-Item -Path $TempModulePath -Recurse -Force
+        }
+    }
+}
+
+function Get-PSHome {
+    $PowerShellFolder = $PSHOME
+
+    # install powershell core if test framework is coreclr
+    if(($env:PowerShellEdition -eq 'Core') -and $script:IsWindows)
+    {
+        if(-not (Get-PackageProvider -Name PSL -ErrorAction Ignore)) {
+            $null = Install-PackageProvider -Name PSL -Force
+        }
+
+        $PowerShellCore = (Get-Package -Provider PSL -Name PowerShell -ErrorAction Ignore)
+        if ($PowerShellCore)
+        {
+            Write-Warning ("PowerShell already installed" -f $PowerShellCore.Name)
+        }
+        else
+        {   
+            $PowerShellCore = Install-Package PowerShell -Provider PSL -Force
+        }
+
+        $PowerShellVersion = $PowerShellCore.Version
+        Write-Host ("PowerShell Version '{0}'" -f $PowerShellVersion)
+
+        $PowerShellFolder = "$Env:ProgramFiles\PowerShell\$PowerShellVersion"
+        Write-Host ("PowerShell Folder '{0}'" -f $PowerShellFolder)
+    }
+
+    return $PowerShellFolder
+}
+
+function Invoke-PowerShellGetTest {
+    $env:APPVEYOR_TEST_PASS = $true
+    $ClonedProjectPath = Resolve-Path "$PSScriptRoot\.."    
+    $PowerShellGetTestsPath = "$ClonedProjectPath\Tests\"
+    $PowerShellHome = Get-PSHome
+    $PowerShellExePath = "$PowerShellHome\PowerShell.exe"
+
+    $AllUsersModulesPath = $script:ProgramFilesModulesPath
+    if(($env:PowerShellEdition -eq 'Core') -and $script:IsWindows)
+    {
+        $AllUsersModulesPath = Microsoft.PowerShell.Management\Join-Path -Path $PowerShellHome -ChildPath 'Modules'
+    }
+
+    # Copy OneGet and PSGet modules to PSHOME    
+    $PowerShellGetSourcePath = Microsoft.PowerShell.Management\Join-Path -Path $ClonedProjectPath -ChildPath $script:PowerShellGet
+    $PowerShellGetModuleInfo = Test-ModuleManifest "$PowerShellGetSourcePath\PowerShellGet.psd1"
+    $ModuleVersion = "$($PowerShellGetModuleInfo.Version)"
+
+    $InstallLocation =  Microsoft.PowerShell.Management\Join-Path -Path $AllUsersModulesPath -ChildPath 'PowerShellGet'
+
+    if($PSVersionTable.PSVersion -ge '5.0.0')
+    {
+        $InstallLocation = Microsoft.PowerShell.Management\Join-Path -Path $InstallLocation -ChildPath $ModuleVersion
+    }
+    $null = New-Item -Path $InstallLocation -ItemType Directory -Force
+    Microsoft.PowerShell.Management\Copy-Item -Path "$PowerShellGetSourcePath\*" -Destination $InstallLocation -Recurse -Force
+
+    & $PowerShellExePath -Command @'
+        $env:PSModulePath;
+        $PSVersionTable;
+        Get-PSRepository;
+        Get-PackageProvider;
+        Get-Module;
+'@
+
+    try {
+        Push-Location $PowerShellGetTestsPath
+
+        $TestResultsFile = Microsoft.PowerShell.Management\Join-Path -Path $PowerShellGetTestsPath -ChildPath 'TestResults.xml'
+        & $PowerShellExePath -Command "Invoke-Pester -Script $PowerShellGetTestsPath -OutputFormat NUnitXml -OutputFile $TestResultsFile -PassThru -Tag BVT"
+
+        $TestResults = [xml](Get-Content -Raw -Path $TestResultsFile)
+        if ([int]$TestResults.'test-results'.failures -gt 0)
+        {
+            throw "$($TestResults.'test-results'.failures) tests failed"
+        }
+    }
+    finally {
+        Pop-Location
+    }
+
+    # Packing
+    $stagingDirectory = Microsoft.PowerShell.Management\Split-Path $ClonedProjectPath.Path -Parent
+    $zipFile = Microsoft.PowerShell.Management\Join-Path $stagingDirectory "$(Split-Path $ClonedProjectPath.Path -Leaf).zip"
+    
+    if($PSEdition -eq 'Desktop')
+    {
+        Add-Type -assemblyname System.IO.Compression.FileSystem
+    }
+
+    Write-Verbose "Zipping $ClonedProjectPath into $zipFile" -verbose
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($ClonedProjectPath.Path, $zipFile)
+}

--- a/tools/build.psm1
+++ b/tools/build.psm1
@@ -43,8 +43,14 @@ if($script:IsWindows) {
     $script:PSGetAppLocalPath = "$HOME/.config/powershell/powershellget"
 }
 
+$script:PowerShellEdition = [System.Environment]::GetEnvironmentVariable("PowerShellEdition")
+if($script:IsWindows)
+{
+    Write-Host "PowerShellEdition value: $script:PowerShellEdition"
+}
+
 function Install-Dependencies {
-    if($env:PowerShellEdition -eq 'Desktop') {
+    if($script:PowerShellEdition -eq 'Desktop') {
         # Download the NuGet.exe from http://nuget.org/NuGet.exe
         $NuGetExeName = 'NuGet.exe'
         if(-not (Microsoft.PowerShell.Management\Test-Path -Path $script:PSGetProgramDataPath))
@@ -62,7 +68,7 @@ function Install-Dependencies {
 
         $AllUsersModulesPath = $script:ProgramFilesModulesPath
         <# TODO: Install latest version of OneGet on PSCore
-        if(($env:PowerShellEdition -eq 'Core') -and $script:IsWindows)
+        if(($script:PowerShellEdition -eq 'Core') -and $script:IsWindows)
         {
             $AllUsersModulesPath = Microsoft.PowerShell.Management\Join-Path -Path (Get-PSHome) -ChildPath 'Modules'
         }
@@ -99,7 +105,7 @@ function Get-PSHome {
     $PowerShellFolder = $PSHOME
 
     # install powershell core if test framework is coreclr
-    if(($env:PowerShellEdition -eq 'Core') -and $script:IsWindows)
+    if(($script:PowerShellEdition -eq 'Core') -and $script:IsWindows)
     {
         if(-not (Get-PackageProvider -Name PSL -ErrorAction Ignore)) {
             $null = Install-PackageProvider -Name PSL -Force
@@ -133,7 +139,7 @@ function Invoke-PowerShellGetTest {
     $PowerShellExePath = "$PowerShellHome\PowerShell.exe"
 
     $AllUsersModulesPath = $script:ProgramFilesModulesPath
-    if(($env:PowerShellEdition -eq 'Core') -and $script:IsWindows)
+    if(($script:PowerShellEdition -eq 'Core') -and $script:IsWindows)
     {
         $AllUsersModulesPath = Microsoft.PowerShell.Management\Join-Path -Path $PowerShellHome -ChildPath 'Modules'
     }
@@ -155,8 +161,8 @@ function Invoke-PowerShellGetTest {
     & $PowerShellExePath -Command @'
         $env:PSModulePath;
         $PSVersionTable;
-        Get-PSRepository;
         Get-PackageProvider;
+        Get-PSRepository -Verbose;
         Get-Module;
 '@
 

--- a/tools/download.sh
+++ b/tools/download.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+# Let's quit on interrupt of subcommands
+trap '
+  trap - INT # restore default INT handler
+  echo "Interrupted"
+  kill -s INT "$$"
+' INT
+
+get_url() {
+    release=v6.0.0-alpha.11
+    echo "https://github.com/PowerShell/PowerShell/releases/download/$release/$1"
+}
+
+# Get OS specific asset ID and package name
+case "$OSTYPE" in
+    linux*)
+        source /etc/os-release
+        # Install curl and wget to download package
+        case "$ID" in
+            centos*)
+                if ! hash curl 2>/dev/null; then
+                    echo "curl not found, installing..."
+                    sudo yum install -y curl
+                fi
+
+                package=powershell-6.0.0_alpha.11-1.el7.centos.x86_64.rpm
+                ;;
+            ubuntu)
+                if ! hash curl 2>/dev/null; then
+                    echo "curl not found, installing..."
+                    sudo apt-get install -y curl
+                fi
+
+                case "$VERSION_ID" in
+                    14.04)
+                        package=powershell_6.0.0-alpha.11-1ubuntu1.14.04.1_amd64.deb
+                        ;;
+                    16.04)
+                        package=powershell_6.0.0-alpha.11-1ubuntu1.16.04.1_amd64.deb
+                        ;;
+                    *)
+                        echo "Ubuntu $VERSION_ID is not supported!" >&2
+                        exit 2
+                esac
+                ;;
+            *)
+                echo "$NAME is not supported!" >&2
+                exit 2
+        esac
+        ;;
+    darwin*)
+        # We don't check for curl as macOS should have a system version
+        package=powershell-6.0.0-alpha.11.pkg
+        ;;
+    *)
+        echo "$OSTYPE is not supported!" >&2
+        exit 2
+        ;;
+esac
+
+curl -L -o "$package" $(get_url "$package")
+
+if [[ ! -r "$package" ]]; then
+    echo "ERROR: $package failed to download! Aborting..." >&2
+    exit 1
+fi
+
+# Installs PowerShell package
+case "$OSTYPE" in
+    linux*)
+        source /etc/os-release
+        # Install dependencies
+        echo "Installing PowerShell with sudo..."
+        case "$ID" in
+            centos)
+                # yum automatically resolves dependencies for local packages
+                sudo yum install "./$package"
+                ;;
+            ubuntu)
+                # dpkg does not automatically resolve dependencies, but spouts ugly errors
+                sudo dpkg -i "./$package" &> /dev/null
+                # Resolve dependencies
+                sudo apt-get install -f
+                ;;
+            *)
+        esac
+        ;;
+    darwin*)
+        patched=0
+        if hash brew 2>/dev/null; then
+            if [[ ! -d $(brew --prefix openssl) ]]; then
+               echo "Installing OpenSSL with brew..."
+               if ! brew install openssl; then
+                   echo "ERROR: OpenSSL failed to install! Crypto functions will not work..." >&2
+                   # Don't abort because it is not fatal
+               elif ! brew install curl --with-openssl; then
+                   echo "ERROR: curl failed to build against OpenSSL; SSL functions will not work..." >&2
+                   # Still not fatal
+               else
+                   # OpenSSL installation succeeded; remember to patch System.Net.Http after PowerShell installation
+                   patched=1
+               fi
+            fi
+
+        else
+            echo "ERROR: brew not found! OpenSSL may not be available..." >&2
+            # Don't abort because it is not fatal
+        fi
+
+        echo "Installing $package with sudo ..."
+        sudo installer -pkg "./$package" -target /
+        if [[ $patched -eq 1 ]]; then
+            echo "Patching System.Net.Http for libcurl and OpenSSL..."
+            find /usr/local/microsoft/powershell -name System.Net.Http.Native.dylib | xargs sudo install_name_tool -change /usr/lib/libcurl.4.dylib /usr/local/opt/curl/lib/libcurl.4.dylib
+        fi
+        ;;
+esac
+
+powershell -noprofile -c '"Congratulations! PowerShell is installed at $PSHOME"'
+success=$?
+
+if [[ "$success" != 0 ]]; then
+    echo "ERROR: PowerShell failed to install!" >&2
+    exit "$success"
+fi

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -1,0 +1,5 @@
+set -x
+ulimit -n 4096
+
+sudo powershell -c "Import-Module ./build.psm1; Install-Dependencies; Invoke-PowerShellGetTest;"
+    

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -1,5 +1,5 @@
 set -x
 ulimit -n 4096
 
-sudo powershell -c "Import-Module ./build.psm1; Install-Dependencies; Invoke-PowerShellGetTest;"
+sudo powershell -c "Import-Module ./tools/build.psm1; Install-Dependencies; Invoke-PowerShellGetTest;"
     


### PR DESCRIPTION
- Integrated with TravisCI for both Linux and OSx platforms. Added required build, test actions and .travis.yml file.
- Integrated with AppVeyor for PowerShellCore validation on Windows. Added required functionality in build.psm1 file to bootstrap the PowerShellCore on Windows AppVeyor VM.
- Enabled all PowerShellGet tests on Linux, OSx with PS Core and on Windows with both PS and PSCore.
- Added Contributing.md and Issue_Template.md
- Updated README.md with the build status badges from AppVeyor and TravisCI for both master and development branches.
- Changed minimum required version of PackageManagement module back to 1.0.0.1 so that PowerShellGet module works fine on Linux and Mac OSx platforms.
- Renamed PublishModuleIsNotSupportedOnNanoServer errorid to PublishModuleIsNotSupportedOnPowerShellCoreEdition, similarly renamed PublishScriptIsNotSupportedOnNanoServer to PublishScriptIsNotSupportedOnPowerShellCoreEdition.
- Fixed an issue in Update-Module and Update-Script cmdlets to show proper version of current item being updated in Confirm/WhatIf message.
- Updated Test-ModuleInstalled function to return single module instead of multiple modules.
- Updated ModuleCommandAlreadyAvailable error message to include all conflicting commands instead of one. Corresponding changes to collect the complete set of conflicting commands from the being installed. 
  Also ensured that conflicting commands from PSModule.psm1 are ignored in the command collision analysis as Get-Command includes the commands from current local scope as well.

@KrishnaV-MSFT @jianyunt : Please CR this PR.