### PR TITLE
Update PowerShell Core release version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os:
   - osx
 sudo: required
 dist: trusty
-osx_image: xcode7.3
+osx_image: xcode8.2
 
 matrix:
   allow_failures:
@@ -31,7 +31,7 @@ install:
   - popd
   # Default 2.0.0 Ruby is buggy
   # Default bundler version is buggy
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm use 2.2.1; gem uninstall bundler -v1.13.1; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm install ruby-2.3.1; rvm use 2.3.1; gem uninstall bundler -v1.13.1; fi
 
 script: 
   - echo "TRAVIS_EVENT_TYPE value $TRAVIS_EVENT_TYPE"

--- a/README.md
+++ b/README.md
@@ -93,24 +93,41 @@ Get PowerShellGet Module
 
 ### Get the latest version from PowerShell Gallery
 
-Before updating PowerShellGet, you should always install the latest Nuget provider. To do that, run the following in an elevated PowerShell session.
+- Before updating PowerShellGet, you should always install the latest Nuget provider. To do that, run the following in an elevated PowerShell session.
 ```powershell
-Install-PackageProvider Nuget –force –verbose
-# exit the session
+Install-PackageProvider Nuget –Force
+Exit
 ```
 
-For systems with PowerShell 5.0 (or greater) you can install both PowerShellGet. 
-To do this on Windows 10, Windows Server 2016, or any system with WMF 5.0 or 5.1 installed, run the following commands from an elevated PowerShell session.
+#### For systems with PowerShell 5.0 (or newer) you can install both PowerShellGet 
+- To do this on Windows 10, Windows Server 2016, or any system with WMF 5.0 or 5.1 installed, run the following commands from an elevated PowerShell session.
 ```powershell
 Install-Module –Name PowerShellGet –Force
-# exit the session
+Exit
 ```
 
-Use Update-Module to get the next updated versions.
+- Use Update-Module to get the next updated versions.
 ```powershell
 Update-Module -Name PowerShellGet
-# exit the session
+Exit
 ```
+
+#### For systems running PowerShell 3 or PowerShell 4, that have installed the [PackageManagement MSI](http://go.microsoft.com/fwlink/?LinkID=746217&clcid=0x409)
+
+- Use below PowerShellGet cmdlet to save the modules to a local directory
+
+```powershell
+Save-Module PowerShellGet -Path C:\LocalFolder
+Exit
+```
+
+- Re-open the PS Console then run the following commands
+
+```powershell
+Copy-Item "C:\LocalFolder\PowerShellGet\*" "$env:ProgramFiles\WindowsPowerShell\Modules\PowerShellGet\" -Recurse -Force
+Copy-Item "C:\LocalFolder\PackageManagement\*" "$env:ProgramFiles\WindowsPowerShell\Modules\PackageManagement\" -Recurse -Force
+```
+
 
 ### Source
 

--- a/tools/build.psm1
+++ b/tools/build.psm1
@@ -117,32 +117,36 @@ function Install-Dependencies {
 }
 
 function Get-PSHome {
-    $PowerShellFolder = $PSHOME
+    $PowerShellHome = $PSHOME
 
     # Install PowerShell Core MSI on Windows.
     if(($script:PowerShellEdition -eq 'Core') -and $script:IsWindows)
     {
         $PowerShellMsiPath = Get-PowerShellCoreBuild -AppVeyorProjectName 'PowerShell'
+        $PowerShellInstallPath = "$env:SystemDrive\PowerShellCore"
         <#
         $PowerShellMsiUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-alpha.11/PowerShell_6.0.0.11-alpha.11-win81-x64.msi'
         $PowerShellMsiName = 'PowerShell_6.0.0.11-alpha.11-win81-x64.msi'
         $PowerShellMsiPath = Microsoft.PowerShell.Management\Join-Path -Path $PSScriptRoot -ChildPath $PowerShellMsiName
         Microsoft.PowerShell.Utility\Invoke-WebRequest -Uri $PowerShellMsiUrl -OutFile $PowerShellMsiPath
         #>
-        $PowerShellVersion = ((Split-Path $PowerShellMsiPath -Leaf) -split '[_-]',3)[1]
-        Start-Process -FilePath "$env:SystemRoot\System32\msiexec.exe" -ArgumentList "/qb /i $PowerShellMsiPath" -Wait
-        Write-Host ("PowerShell Version '{0}'" -f $PowerShellVersion)
-
-        $PowerShellFolder = "$Env:ProgramFiles\PowerShell\$PowerShellVersion"
-        Write-Host ("PowerShell Folder '{0}'" -f $PowerShellFolder)
-
-        if(-not (Microsoft.PowerShell.Management\Test-Path -Path $PowerShellFolder -PathType Container))
-        {
-            Throw "$PowerShellFolder path is not available."        
+        Start-Process -FilePath "$env:SystemRoot\System32\msiexec.exe" -ArgumentList "/qb INSTALLFOLDER=$PowerShellInstallPath /i $PowerShellMsiPath" -Wait
+        
+        $PowerShellVersionPath = Get-ChildItem -Path $PowerShellInstallPath -Attributes Directory | Select-Object -First 1 -ErrorAction Ignore
+        $PowerShellHome = $null
+        if ($PowerShellVersionPath) {
+            $PowerShellHome = $PowerShellVersionPath.FullName
         }
+        
+        if(-not $PowerShellHome -or -not (Microsoft.PowerShell.Management\Test-Path -Path $PowerShellHome -PathType Container))
+        {
+            Throw "$PowerShellHome path is not available."  
+        }
+
+        Write-Host ("PowerShell Home Path '{0}'" -f $PowerShellHome)
     }
 
-    return $PowerShellFolder
+    return $PowerShellHome
 }
 
 function Invoke-PowerShellGetTest {    

--- a/tools/download.sh
+++ b/tools/download.sh
@@ -8,7 +8,7 @@ trap '
 ' INT
 
 get_url() {
-    release=v6.0.0-alpha.13
+    release=v6.0.0-alpha.14
     echo "https://github.com/PowerShell/PowerShell/releases/download/$release/$1"
 }
 
@@ -24,7 +24,7 @@ case "$OSTYPE" in
                     sudo yum install -y curl
                 fi
 
-                package=powershell-6.0.0_alpha.13-1.el7.centos.x86_64.rpm
+                package=powershell-6.0.0_alpha.14-1.el7.centos.x86_64.rpm
                 ;;
             ubuntu)
                 if ! hash curl 2>/dev/null; then
@@ -34,10 +34,10 @@ case "$OSTYPE" in
 
                 case "$VERSION_ID" in
                     14.04)
-                        package=powershell_6.0.0-alpha.13-1ubuntu1.14.04.1_amd64.deb
+                        package=powershell_6.0.0-alpha.14-1ubuntu1.14.04.1_amd64.deb
                         ;;
                     16.04)
-                        package=powershell_6.0.0-alpha.13-1ubuntu1.16.04.1_amd64.deb
+                        package=powershell_6.0.0-alpha.14-1ubuntu1.16.04.1_amd64.deb
                         ;;
                     *)
                         echo "Ubuntu $VERSION_ID is not supported!" >&2
@@ -51,7 +51,7 @@ case "$OSTYPE" in
         ;;
     darwin*)
         # We don't check for curl as macOS should have a system version
-        package=powershell-6.0.0-alpha.13.pkg
+        package=powershell-6.0.0-alpha.14.pkg
         ;;
     *)
         echo "$OSTYPE is not supported!" >&2


### PR DESCRIPTION
- Updated PowerShell Core release version in download.sh.
- Updated MSI installation logic as per the recent MSI rename.
- Updated osx_image version to xcode8.2
- Updated Readme.md to include the steps for Updating the PowerShellGet module on PS 3 and 4 versions.