### PR TITLE
Fix Update-Help broken by HTTPS

### DIFF
--- a/PowerShellGet/PowerShellGet.psd1
+++ b/PowerShellGet/PowerShellGet.psd1
@@ -64,5 +64,5 @@ PrivateData = @{
     }
 }
 
-HelpInfoURI = 'https://go.microsoft.com/fwlink/?LinkId=393271'
+HelpInfoURI = 'http://go.microsoft.com/fwlink/?LinkId=393271'
 }


### PR DESCRIPTION
Per Twitter report from @juneb: https://twitter.com/Steve_MSFT/status/811637064684814336

Reminder that HTTPS is not supported in the HelpInfoURI:

```
update-help : Failed to update Help for the module(s) :
'PowerShellGet'
The HelpInfoURI https://go.microsoft.com/fwlink/?LinkId=393271 does not start with HTTP.
At line:1 char:1
+ update-help powershellget
+ ~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (HelpInfoUri:Uri) [Update-Help], Exception
    + FullyQualifiedErrorId : InvalidHelpInfoUriFormat,Microsoft.PowerShell.Commands.UpdateHelpCommand
```