### PR TITLE
Added credential parameter to subsequent calls of Publish-Module/Script.

### DIFF
--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -792,7 +792,7 @@ function Publish-Module
 
         [Parameter(ValueFromPipelineByPropertyName=$true)]
         [PSCredential]
-        $Credential = $null,
+        $Credential,
 
         [Parameter()] 
         [ValidateSet("1.0")]
@@ -1335,7 +1335,7 @@ function Find-Module
 
         [Parameter(ValueFromPipelineByPropertyName=$true)]
         [PSCredential]
-        $Credential = $null
+        $Credential
     )
 
     Begin
@@ -2621,7 +2621,7 @@ function Publish-Script
 
         [Parameter(ValueFromPipelineByPropertyName=$true)]
         [PSCredential]
-        $Credential = $null,
+        $Credential,
 
         [Parameter()]
         [switch]
@@ -7623,7 +7623,7 @@ function ValidateAndGet-ScriptDependencies
 
         [Parameter()]
         [PSCredential]
-        $Credential = $null
+        $Credential
     )
 
     $DependenciesDetails = @()
@@ -7767,7 +7767,7 @@ function ValidateAndGet-RequiredModuleDetails
 
         [Parameter()]
         [PSCredential]
-        $Credential = $null
+        $Credential
     )
 
     $RequiredModuleDetails = @()
@@ -7960,7 +7960,7 @@ function Get-ModuleDependencies
 
         [Parameter()]
         [PSCredential]
-        $Credential = $null
+        $Credential
     )
 
     $DependentModuleDetails = @()
@@ -8062,7 +8062,7 @@ function Publish-PSArtifactUtility
 
         [Parameter()]
         [PSCredential]
-        $Credential = $null,
+        $Credential,
 
         [Parameter(Mandatory=$true)]
         [ValidateNotNullOrEmpty()]

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -1335,7 +1335,7 @@ function Find-Module
 
         [Parameter(ValueFromPipelineByPropertyName=$true)]
         [PSCredential]
-        $Credential
+        $Credential = $null
     )
 
     Begin
@@ -7619,7 +7619,11 @@ function ValidateAndGet-ScriptDependencies
         [parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCmdlet]
-        $CallerPSCmdlet
+        $CallerPSCmdlet,
+
+        [Parameter()]
+        [PSCredential]
+        $Credential = $null
     )
 
     $DependenciesDetails = @()
@@ -7634,6 +7638,7 @@ function ValidateAndGet-ScriptDependencies
 
             $FindModuleArguments = @{
                                         Repository = $Repository
+                                        Credential = $Credential
                                         Verbose = $VerbosePreference
                                         ErrorAction = 'SilentlyContinue'
                                         WarningAction = 'SilentlyContinue'
@@ -7698,6 +7703,7 @@ function ValidateAndGet-ScriptDependencies
         {
             $FindScriptArguments = @{
                                         Repository = $Repository
+                                        Credential = $Credential
                                         Verbose = $VerbosePreference
                                         ErrorAction = 'SilentlyContinue'
                                         WarningAction = 'SilentlyContinue'
@@ -14623,6 +14629,7 @@ function Resolve-Location
         $LocationParameterName,
         
         [Parameter()]
+        [PSCredential]
         $Credential,
 
         [Parameter()]

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -792,7 +792,7 @@ function Publish-Module
 
         [Parameter(ValueFromPipelineByPropertyName=$true)]
         [PSCredential]
-        $Credential,
+        $Credential = $null,
 
         [Parameter()] 
         [ValidateSet("1.0")]
@@ -1236,6 +1236,7 @@ function Publish-Module
                                           -LicenseUri $LicenseUri `
                                           -IconUri $IconUri `
                                           -ProjectUri $ProjectUri `
+                                          -Credential $Credential `
                                           -Verbose:$VerbosePreference `
                                           -WarningAction $WarningPreference `
                                           -ErrorAction $ErrorActionPreference `
@@ -2877,6 +2878,7 @@ function Publish-Script
                                           -Destination $DestinationLocation `
                                           -Repository $Repository `
                                           -NugetPackageRoot $tempScriptPath `
+                                          -Credential $Credential `
                                           -Verbose:$VerbosePreference `
                                           -WarningAction $WarningPreference `
                                           -ErrorAction $ErrorActionPreference `
@@ -7755,7 +7757,11 @@ function ValidateAndGet-RequiredModuleDetails
         [parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCmdlet]
-        $CallerPSCmdlet
+        $CallerPSCmdlet,
+
+        [Parameter()]
+        [PSCredential]
+        $Credential = $null
     )
 
     $RequiredModuleDetails = @()
@@ -7776,6 +7782,7 @@ function ValidateAndGet-RequiredModuleDetails
 
             $FindModuleArguments = @{
                                         Repository = $Repository
+                                        Credential = $Credential
                                         Verbose = $VerbosePreference
                                         ErrorAction = 'SilentlyContinue'
                                         WarningAction = 'SilentlyContinue'
@@ -7864,6 +7871,7 @@ function ValidateAndGet-RequiredModuleDetails
 
         $FindModuleArguments = @{
                                     Repository = $Repository
+                                    Credential = $Credential
                                     Verbose = $VerbosePreference
                                     ErrorAction = 'SilentlyContinue'
                                     WarningAction = 'SilentlyContinue'
@@ -7942,7 +7950,11 @@ function Get-ModuleDependencies
         [parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCmdlet]
-        $CallerPSCmdlet
+        $CallerPSCmdlet,
+
+        [Parameter()]
+        [PSCredential]
+        $Credential = $null
     )
 
     $DependentModuleDetails = @()
@@ -7969,6 +7981,7 @@ function Get-ModuleDependencies
                                                                             -Repository $Repository `
                                                                             -DependentModuleInfo $PSModuleInfo `
                                                                             -CallerPSCmdlet $CallerPSCmdlet `
+                                                                            -Credential $Credential `
                                                                             -Verbose:$VerbosePreference `
                                                                             -Debug:$DebugPreference 
         }
@@ -7997,6 +8010,7 @@ function Get-ModuleDependencies
                                                                             -Repository $Repository `
                                                                             -DependentModuleInfo $PSModuleInfo `
                                                                             -CallerPSCmdlet $CallerPSCmdlet `
+                                                                            -Credential $Credential `
                                                                             -Verbose:$VerbosePreference `
                                                                             -Debug:$DebugPreference 
         }
@@ -8039,6 +8053,10 @@ function Publish-PSArtifactUtility
         [ValidateNotNullOrEmpty()]
         [string]
         $NugetApiKey,
+
+        [Parameter()]
+        [PSCredential]
+        $Credential = $null,
 
         [Parameter(Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
@@ -8198,6 +8216,7 @@ function Publish-PSArtifactUtility
         $DependentModuleDetails += ValidateAndGet-ScriptDependencies -Repository $Repository `
                                                                      -DependentScriptInfo $PSScriptInfo `
                                                                      -CallerPSCmdlet $PSCmdlet `
+                                                                     -Credential $Credential `
                                                                      -Verbose:$VerbosePreference `
                                                                      -Debug:$DebugPreference
     }
@@ -8268,6 +8287,7 @@ function Publish-PSArtifactUtility
         $DependentModuleDetails = Get-ModuleDependencies -PSModuleInfo $PSModuleInfo `
                                                          -Repository $Repository `
                                                          -CallerPSCmdlet $PSCmdlet `
+                                                         -Credential $Credential `
                                                          -Verbose:$VerbosePreference `
                                                          -Debug:$DebugPreference 
     }

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -2621,7 +2621,7 @@ function Publish-Script
 
         [Parameter(ValueFromPipelineByPropertyName=$true)]
         [PSCredential]
-        $Credential,
+        $Credential = $null,
 
         [Parameter()]
         [switch]


### PR DESCRIPTION
This is needed when a module is published that has the RequiredModules attribute in the manifest, and is being published to a Repo that does not have Anonymous access because the required module lookups will fail because there is no read access to repo.