### PR TITLE
Implement Publish-Module credential parameter propagation to sub-functions

### DIFF
--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -8254,12 +8254,19 @@ function Publish-PSArtifactUtility
         }
 
         # Populate the dependencies elements from RequiredModules and RequiredScripts
-        # 
-        $DependentModuleDetails += ValidateAndGet-ScriptDependencies -Repository $Repository `
-                                                                     -DependentScriptInfo $PSScriptInfo `
-                                                                     -CallerPSCmdlet $PSCmdlet `
-                                                                     -Verbose:$VerbosePreference `
-                                                                     -Debug:$DebugPreference
+        #
+        $ValidateAndGetScriptDependencies_Params = @{
+            Repository=$Repository
+            DependentScriptInfo=$PSScriptInfo
+            CallerPSCmdlet=$PSCmdlet
+            Verbose=$VerbosePreference
+            Debug=$DebugPreference
+        }
+        if ($PSBoundParameters.ContainsKey('Credential'))
+        {
+            $ValidateAndGetScriptDependencies_Params.Add('Credential',$Credential)
+        }
+        $DependentModuleDetails += ValidateAndGet-ScriptDependencies @ValidateAndGetScriptDependencies_Params
     }
     else
     {

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -7631,7 +7631,11 @@ function ValidateAndGet-ScriptDependencies
         [parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCmdlet]
-        $CallerPSCmdlet
+        $CallerPSCmdlet,
+
+        [Parameter()]
+        [PSCredential]
+        $Credential
     )
 
     $DependenciesDetails = @()

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -7655,6 +7655,10 @@ function ValidateAndGet-ScriptDependencies
                                         WarningAction = 'SilentlyContinue'
                                         Debug = $DebugPreference
                                     }
+            if ($PSBoundParameters.ContainsKey('Credential'))
+            {
+                $FindModuleArguments.Add('Credential',$Credential)
+            }
 
             if($DependentScriptInfo.ExternalModuleDependencies -contains $ModuleName)
             {
@@ -7719,6 +7723,10 @@ function ValidateAndGet-ScriptDependencies
                                         WarningAction = 'SilentlyContinue'
                                         Debug = $DebugPreference
                                     }
+            if ($PSBoundParameters.ContainsKey('Credential'))
+            {
+                $FindScriptArguments.Add('Credential',$Credential)
+            }
 
             if($DependentScriptInfo.ExternalScriptDependencies -contains $requiredScript)
             {

--- a/PowerShellGet/PowerShellGet.psd1
+++ b/PowerShellGet/PowerShellGet.psd1
@@ -1,6 +1,6 @@
 ﻿@{
 RootModule = 'PSModule.psm1'
-ModuleVersion = '1.1.3.0'
+ModuleVersion = '1.1.3.1'
 GUID = '1d73a601-4a6c-43c5-ba3f-619b18bbb404'
 Author = 'Microsoft Corporation'
 CompanyName = 'Microsoft Corporation'


### PR DESCRIPTION
I want to resolve #103 by:

Add Optional Credential Parameter to the following functions:
- Publish-PSArtifactUtility
- Get-ModuleDependencies
- ValidateAndGet-RequiredModuleDetails
and detect and propaget the Credential parameter if it is been used down
the following path:
Publish-Module -> Publish-PSArtifactUtility -> Get-ModuleDependencies ->
ValidateAndGet-RequiredModuleDetails -> Find-Module