### PR TITLE
Changed Get-EnvironmentVariable to get the unexpanded version of %path%

### DIFF
--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -12078,11 +12078,27 @@ function Get-EnvironmentVariable
     }
     elseif ($Target -eq $script:EnvironmentVariableTarget.Machine)
     {
-        $itemPropertyValue = Microsoft.PowerShell.Management\Get-ItemProperty -Path $script:SystemEnvironmentKey -Name $Name -ErrorAction SilentlyContinue
-
-        if($itemPropertyValue)
+        if ($Name -eq "path")
         {
-            return $itemPropertyValue.$Name
+            # if we need the path environment variable, we need it un-expanded, otherwise
+            # when writing it back, we would loose all the variables like %systemroot% in it.
+            # We use the Win32 API directly using DoNotExpandEnvironmentNames
+            # It is unclear whether any code calling this function for %path% needs the expanded version of %path%
+            # There are currently no tests for this code
+            # Microsoft.PowerShell.Management\Get-ItemProperty is passed through to the PowerShell Registry provider
+            # which currently doesn't seem to support anything like: DoNotExpandEnvironmentNames
+            $hklmHive = [Microsoft.Win32.Registry]::LocalMachine
+            $EnvRegKey = $hklmHive.OpenSubKey("SYSTEM\CurrentControlSet\Control\Session Manager\Environment", $FALSE)
+            $itemPropertyValue = $EnvRegKey.GetValue($Name, "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+            return $itemPropertyValue
+        }
+        else
+        {
+            $itemPropertyValue = Microsoft.PowerShell.Management\Get-ItemProperty -Path $script:SystemEnvironmentKey -Name $Name -ErrorAction SilentlyContinue
+            if($itemPropertyValue)
+            {
+                return $itemPropertyValue.$Name
+            }
         }
     }
     elseif ($Target -eq $script:EnvironmentVariableTarget.User)


### PR DESCRIPTION
This is in regards to issue #116, updating the machine path environment variable in Install-Script removed any variables in that value.

Running the tests for Install-Script did not cover this (and still don't), all the related tests came out as pending. 

I am not sure this change does not have any side effects. Meaning is there code elsewhere that gets the path variable directly from the registry but needs in expanded rather than un-expanded as it is now.