### PR TITLE
Install-Script -Scope CurrentUser PATH changes should not require a reboot for new PS processes

### DIFF
--- a/PowerShellGet/PSGet.Resource.psd1
+++ b/PowerShellGet/PSGet.Resource.psd1
@@ -235,6 +235,8 @@ ConvertFrom-StringData @'
         PublishersMatch=Publisher '{0}' of the new module '{1}' with version '{2}' matches with the publisher '{3}' of the previously-installed module '{4}' with version '{5}'. Both versions are signed with a Microsoft root certificate.        
         PublishersMismatch=A Microsoft-signed module named '{0}' with version '{1}' that was previously installed conflicts with the new module '{2}' from publisher '{3}' with version '{4}'. Installing the new module may result in system instability. If you still want to install or update, use -SkipPublisherCheck parameter.
         ModuleIsNotCatalogSigned=The version '{0}' of the module '{1}' being installed is not catalog signed. Ensure that the version '{0}' of the module '{1}' has the catalog file '{2}' and signed with the same publisher '{3}' as the previously-installed module '{1}' with version '{4}' under the directory '{5}'. If you still want to install or update, use -SkipPublisherCheck parameter.
+        SentEnvironmentVariableChangeMessage=Successfully broadcasted the Environment variable changes.
+        UnableToSendEnvironmentVariableChangeMessage=Error in broadcasting the Environment variable changes.
 ###PSLOC
 '@
 

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -731,7 +731,16 @@ if(-not $script:TelemetryEnabled -and $script:IsWindows)
 {
     try
     {
-        Add-Type -ReferencedAssemblies $requiredAssembly -TypeDefinition $source -Language CSharp -ErrorAction SilentlyContinue
+        $AddType_prams = @{
+            TypeDefinition = $source
+            Language = 'CSharp'            
+            ErrorAction = 'SilentlyContinue'
+        }
+        if (-not $script:IsCoreCLR)
+        {
+            $AddType_prams['ReferencedAssemblies'] = $requiredAssembly
+        }
+        Add-Type @AddType_prams 
     
         # If the telemetry namespace/methods are not found flow goes to the catch block where telemetry is disabled
         $telemetryMethods = ([Microsoft.PowerShell.Commands.PowerShellGet.Telemetry] | Get-Member -Static).Name

--- a/Tests/PSGetUpdateModuleManifest.Tests.ps1
+++ b/Tests/PSGetUpdateModuleManifest.Tests.ps1
@@ -164,7 +164,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         $AliasesToExport = "alias1","alias2"
         $VariablesToExport = "var1","var2"
         $CmdletsToExport="get-test1","get-test2"
-        $HelpInfoURI = "$script:PublishModuleName URL"
+        $HelpInfoURI = "http://$script:UpdateModuleManifestName.com/HelpInfoURI"
         $RequiredModules = @('Microsoft.PowerShell.Management',@{ModuleName='Microsoft.PowerShell.Utility';ModuleVersion='1.0.0.0';GUID='1da87e53-152b-403e-98dc-74d7b4d63d59'})
         $NestedModules = "Microsoft.PowerShell.Management","Microsoft.PowerShell.Utility"
         $ScriptsToProcess = "$script:UpdateModuleManifestName.ps1"
@@ -248,7 +248,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         }
       
         Assert ($newModuleInfo.Scripts -contains $ScriptsToProcessFilePath) "ScriptsToProcess should include $($ScriptsToProcess)"
-        AssertEquals $newModuleInfo.HelpInfoUri $HelpInfoURI "HelpInfoURI should be $($HelpInfoURI)"
+        $newModuleInfo.HelpInfoUri | Should Be $HelpInfoURI
     } `
     -Skip:$($IsWindows -eq $False)
 
@@ -287,7 +287,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         $AliasesToExport = "alias1","alias2"
         $VariablesToExport = "var1","var2"
         $CmdletsToExport="get-test1","get-test2"
-        $HelpInfoURI = "$script:PublishModuleName URL"
+        $HelpInfoURI = "http://$script:UpdateModuleManifestName.com/HelpInfoURI"
         $RequiredModules = @('Microsoft.PowerShell.Management',@{ModuleName='Microsoft.PowerShell.Utility';ModuleVersion='1.0.0.0';GUID='1da87e53-152b-403e-98dc-74d7b4d63d59'})
         $NestedModules = "Microsoft.PowerShell.Management","Microsoft.PowerShell.Utility"
         $ExternalModuleDependencies = "Microsoft.PowerShell.Management","Microsoft.PowerShell.Utility"
@@ -368,7 +368,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
             AssertEquals $newModuleInfo.ReleaseNotes $ReleaseNotes "ReleaseNotes should be $($ReleaseNotes)"
         }
        
-        AssertEquals $newModuleInfo.HelpInfoUri $HelpInfoURI "HelpInfoURI should be $($HelpInfoURI)"
+        $newModuleInfo.HelpInfoUri | Should Be $HelpInfoURI
         Assert ($newModuleInfo.PrivateData.PSData.ExternalModuleDependencies -contains $ExternalModuleDependencies[0]) "ExternalModuleDependencies should include $($ExternalModuleDependencies[0])"
         Assert ($newModuleInfo.PrivateData.PSData.ExternalModuleDependencies -contains $ExternalModuleDependencies[1]) "ExternalModuleDependencies should include $($ExternalModuleDependencies[1])"
     } `

--- a/Tests/Pester.CatalogSignedModules.Tests.ps1
+++ b/Tests/Pester.CatalogSignedModules.Tests.ps1
@@ -457,16 +457,13 @@ Describe 'Update-Module --- Microsoft signed versions of Microsoft.PowerShell.Ar
             Install-Module -Name $MicrosoftPowerShellArchive -RequiredVersion 1.0.1.1 -Repository $Script:INTRepositoryName -Force
         }
 
-        Get-InstalledModule -Name $MicrosoftPowerShellArchive -RequiredVersion 1.0.1.3 -ErrorAction SilentlyContinue | PowerShellGet\Uninstall-Module
-        Get-InstalledModule -Name $MicrosoftPowerShellArchive -RequiredVersion 1.0.1.4 -ErrorAction SilentlyContinue | PowerShellGet\Uninstall-Module
-        Get-InstalledModule -Name $MicrosoftPowerShellArchive -RequiredVersion 1.0.1.2 -ErrorAction SilentlyContinue | PowerShellGet\Uninstall-Module
-        Get-InstalledModule -Name $MicrosoftPowerShellArchive -RequiredVersion 1.0.1.11 -ErrorAction SilentlyContinue | PowerShellGet\Uninstall-Module
+        Get-InstalledModule -Name $MicrosoftPowerShellArchive -ErrorAction SilentlyContinue | Where-Object {$_.Version -gt "1.0.1.1" } | PowerShellGet\Uninstall-Module
         Get-InstalledModule -Name $TestArchiveModule -RequiredVersion 1.0.1.11 -ErrorAction SilentlyContinue | PowerShellGet\Uninstall-Module
     }
 
     It 'Update-Module Microsoft.PowerShell.Archive -- Update a catalog signed module: Should work' {
         Update-Module -Name $MicrosoftPowerShellArchive
-        Get-InstalledModule -Name $MicrosoftPowerShellArchive -RequiredVersion 1.0.1.11 | Should Not BeNullOrEmpty
+        Get-InstalledModule -Name $MicrosoftPowerShellArchive -MinimumVersion 1.0.1.11 | Should Not BeNullOrEmpty
         
         if($PSVersionTable.PSVersion -ge '5.0.0') {
             Get-InstalledModule -Name $MicrosoftPowerShellArchive -RequiredVersion 1.0.1.1 | Should Not BeNullOrEmpty
@@ -475,7 +472,7 @@ Describe 'Update-Module --- Microsoft signed versions of Microsoft.PowerShell.Ar
 
     It 'Update-Module Microsoft.PowerShell.Archive -- Update a catalog signed module without specifying a name: Should work' {
         Update-Module
-        Get-InstalledModule -Name $MicrosoftPowerShellArchive -RequiredVersion 1.0.1.11 | Should Not BeNullOrEmpty
+        Get-InstalledModule -Name $MicrosoftPowerShellArchive -MinimumVersion 1.0.1.11 | Should Not BeNullOrEmpty
         
         if($PSVersionTable.PSVersion -ge '5.0.0') {
             Get-InstalledModule -Name $MicrosoftPowerShellArchive -RequiredVersion 1.0.1.1 | Should Not BeNullOrEmpty

--- a/tools/download.sh
+++ b/tools/download.sh
@@ -8,10 +8,12 @@ trap '
 ' INT
 
 get_url() {
-    release=v6.0.0-alpha.14
-    echo "https://github.com/PowerShell/PowerShell/releases/download/$release/$1"
+    fork=$2
+    release=v6.0.0-beta.1
+    echo "https://github.com/$fork/PowerShell/releases/download/$release/$1"
 }
 
+fork="PowerShell"
 # Get OS specific asset ID and package name
 case "$OSTYPE" in
     linux*)
@@ -24,7 +26,7 @@ case "$OSTYPE" in
                     sudo yum install -y curl
                 fi
 
-                package=powershell-6.0.0_alpha.14-1.el7.centos.x86_64.rpm
+                package=powershell-6.0.0_beta.1-1.el7.centos.x86_64.rpm
                 ;;
             ubuntu)
                 if ! hash curl 2>/dev/null; then
@@ -34,13 +36,29 @@ case "$OSTYPE" in
 
                 case "$VERSION_ID" in
                     14.04)
-                        package=powershell_6.0.0-alpha.14-1ubuntu1.14.04.1_amd64.deb
+                        package=powershell_6.0.0-beta.1-1ubuntu1.14.04.1_amd64.deb
                         ;;
                     16.04)
-                        package=powershell_6.0.0-alpha.14-1ubuntu1.16.04.1_amd64.deb
+                        package=powershell_6.0.0-beta.1-1ubuntu1.16.04.1_amd64.deb
                         ;;
                     *)
                         echo "Ubuntu $VERSION_ID is not supported!" >&2
+                        exit 2
+                esac
+                ;;
+            opensuse)
+                if ! hash curl 2>/dev/null; then
+                    echo "curl not found, installing..."
+                    sudo zypper install -y curl
+                fi
+
+                
+                case "$VERSION_ID" in
+                    42.1)
+                        package=powershell-6.0.0_beta.1-1.suse.42.1.x86_64.rpm
+                        ;;
+                    *)
+                        echo "OpenSUSE $VERSION_ID is not supported!" >&2
                         exit 2
                 esac
                 ;;
@@ -51,7 +69,7 @@ case "$OSTYPE" in
         ;;
     darwin*)
         # We don't check for curl as macOS should have a system version
-        package=powershell-6.0.0-alpha.14.pkg
+        package=powershell-6.0.0-beta.1-osx.10.12-x64.pkg
         ;;
     *)
         echo "$OSTYPE is not supported!" >&2
@@ -59,7 +77,7 @@ case "$OSTYPE" in
         ;;
 esac
 
-curl -L -o "$package" $(get_url "$package")
+curl -L -o "$package" $(get_url "$package" "$fork")
 
 if [[ ! -r "$package" ]]; then
     echo "ERROR: $package failed to download! Aborting..." >&2
@@ -82,6 +100,12 @@ case "$OSTYPE" in
                 sudo dpkg -i "./$package" &> /dev/null
                 # Resolve dependencies
                 sudo apt-get install -f
+                ;;
+            opensuse)
+                # Install the Microsoft public key so that zypper trusts the package
+                sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+                # zypper automatically resolves dependencies for local packages
+                sudo zypper --non-interactive install "./$package" &> /dev/null
                 ;;
             *)
         esac


### PR DESCRIPTION
- Made changes to broadcast the Environment variable changes, so that other processes pick changes to Environment variables without having to reboot or logoff/logon. (Resolves #81)
* Fixed Add-Type issue in v6.0.0-beta.1 release of PowerShellCore. (Resolves #125)
* Updated PowerShellCore version in download.sh file.
* Updated the failing test cases.