### PR TITLE
Bug fix: Update-ModuleManifest -PrivateData @{ExternalModuleDependencies='SomeModule'} should write the ExternalModuleDependencies as @() in the ModuleManifest`s Private Data

### DIFF
--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -8254,12 +8254,19 @@ function Publish-PSArtifactUtility
         }
 
         # Populate the dependencies elements from RequiredModules and RequiredScripts
-        # 
-        $DependentModuleDetails += ValidateAndGet-ScriptDependencies -Repository $Repository `
-                                                                     -DependentScriptInfo $PSScriptInfo `
-                                                                     -CallerPSCmdlet $PSCmdlet `
-                                                                     -Verbose:$VerbosePreference `
-                                                                     -Debug:$DebugPreference
+        #
+        $ValidateAndGetScriptDependencies_Params = @{
+            Repository=$Repository
+            DependentScriptInfo=$PSScriptInfo
+            CallerPSCmdlet=$PSCmdlet
+            Verbose=$VerbosePreference
+            Debug=$DebugPreference
+        }
+        if ($PSBoundParameters.ContainsKey('Credential'))
+        {
+            $ValidateAndGetScriptDependencies_Params.Add('Credential',$Credential)
+        }
+        $DependentModuleDetails += ValidateAndGet-ScriptDependencies @ValidateAndGetScriptDependencies_Params
     }
     else
     {

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -183,6 +183,7 @@ $script:DefinedCommands  = 'DefinedCommands'
 $script:DefinedFunctions = 'DefinedFunctions'
 $script:DefinedWorkflows = 'DefinedWorkflows'
 $script:TextInfo = (Get-Culture).TextInfo
+$script:PrivateData = 'PrivateData'
 
 $script:PSScriptInfoProperties = @($script:Name
                                    $script:Version,
@@ -204,7 +205,8 @@ $script:PSScriptInfoProperties = @($script:Name
                                    $script:IconUri,
                                    $script:DefinedCommands,
                                    $script:DefinedFunctions,
-                                   $script:DefinedWorkflows
+                                   $script:DefinedWorkflows,
+								   $script:PrivateData
                                    )
 
 $script:SystemEnvironmentKey = 'HKLM:\System\CurrentControlSet\Control\Session Manager\Environment'
@@ -4553,6 +4555,8 @@ Feature 3
 Feature 4
 Feature 5
 
+.PRIVATEDATA Contoso private data
+
 #>
 
 <# #Requires -Module statements #>
@@ -4989,6 +4993,11 @@ function New-ScriptFileInfo
         [Parameter()]
         [string[]]
         $ReleaseNotes,
+
+		[Parameter()]
+		[ValidateNotNullOrEmpty()]
+        [string]
+        $PrivateData,
                 
         [Parameter()]
         [switch]
@@ -5073,6 +5082,7 @@ function New-ScriptFileInfo
             LicenseUri = $LicenseUri
             IconUri = $IconUri
             ReleaseNotes = $ReleaseNotes
+			PrivateData = $PrivateData
         }
 
         if(-not (Validate-ScriptFileInfoParameters -parameters $params))
@@ -5239,6 +5249,10 @@ function Update-ScriptFileInfo
         [Parameter()]
         [string[]]
         $ReleaseNotes,
+
+		[Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$PrivateData,
                 
         [Parameter()]
         [switch]
@@ -5435,6 +5449,7 @@ function Update-ScriptFileInfo
             LicenseUri = $LicenseUri
             IconUri = $IconUri
             ReleaseNotes = $ReleaseNotes
+			PrivateData = $PrivateData
         }
 
         if(-not (Validate-ScriptFileInfoParameters -parameters $params))
@@ -5802,7 +5817,11 @@ function Get-PSScriptInfoString
 
         [Parameter()]
         [string[]]
-        $ReleaseNotes
+        $ReleaseNotes,
+
+		[Parameter()]
+        [string]
+        $PrivateData
     )
 
     Process
@@ -5837,6 +5856,8 @@ function Get-PSScriptInfoString
 
 .RELEASENOTES
 $($ReleaseNotes -join "`r`n")
+
+.PRIVATEDATA $PrivateData
 
 #>
 "@
@@ -8685,6 +8706,8 @@ function ValidateAndAdd-PSScriptInfoEntry
         $script:DefinedFunctions { $KeyName = $script:DefinedFunctions }
 
         $script:DefinedWorkflows { $KeyName = $script:DefinedWorkflows }
+
+		$script:PrivateData { $KeyName = $script:PrivateData }
     }
 
     Microsoft.PowerShell.Utility\Add-Member -InputObject $PSScriptInfo `
@@ -12094,11 +12117,11 @@ function Get-EnvironmentVariable
         }
         else
         {
-            $itemPropertyValue = Microsoft.PowerShell.Management\Get-ItemProperty -Path $script:SystemEnvironmentKey -Name $Name -ErrorAction SilentlyContinue
-            if($itemPropertyValue)
-            {
-                return $itemPropertyValue.$Name
-            }
+        $itemPropertyValue = Microsoft.PowerShell.Management\Get-ItemProperty -Path $script:SystemEnvironmentKey -Name $Name -ErrorAction SilentlyContinue
+
+        if($itemPropertyValue)
+        {
+            return $itemPropertyValue.$Name
         }
     }
     elseif ($Target -eq $script:EnvironmentVariableTarget.User)
@@ -12578,6 +12601,7 @@ function Get-OrderedPSScriptInfoObject
                             $script:DefinedCommands = $PSScriptInfo.$script:DefinedCommands
                             $script:DefinedFunctions = $PSScriptInfo.$script:DefinedFunctions
                             $script:DefinedWorkflows = $PSScriptInfo.$script:DefinedWorkflows
+							$script:PrivateData = $PSScriptInfo.$script:PrivateData
                         })
 
     $NewPSScriptInfo.PSTypeNames.Insert(0, "Microsoft.PowerShell.Commands.PSScriptInfo")

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -7631,7 +7631,11 @@ function ValidateAndGet-ScriptDependencies
         [parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCmdlet]
-        $CallerPSCmdlet
+        $CallerPSCmdlet,
+
+        [Parameter()]
+        [PSCredential]
+        $Credential
     )
 
     $DependenciesDetails = @()

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -12117,11 +12117,12 @@ function Get-EnvironmentVariable
         }
         else
         {
-        $itemPropertyValue = Microsoft.PowerShell.Management\Get-ItemProperty -Path $script:SystemEnvironmentKey -Name $Name -ErrorAction SilentlyContinue
+            $itemPropertyValue = Microsoft.PowerShell.Management\Get-ItemProperty -Path $script:SystemEnvironmentKey -Name $Name -ErrorAction SilentlyContinue
 
-        if($itemPropertyValue)
-        {
-            return $itemPropertyValue.$Name
+            if($itemPropertyValue)
+            {
+                return $itemPropertyValue.$Name
+            }
         }
     }
     elseif ($Target -eq $script:EnvironmentVariableTarget.User)

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -7655,6 +7655,10 @@ function ValidateAndGet-ScriptDependencies
                                         WarningAction = 'SilentlyContinue'
                                         Debug = $DebugPreference
                                     }
+            if ($PSBoundParameters.ContainsKey('Credential'))
+            {
+                $FindModuleArguments.Add('Credential',$Credential)
+            }
 
             if($DependentScriptInfo.ExternalModuleDependencies -contains $ModuleName)
             {
@@ -7719,6 +7723,10 @@ function ValidateAndGet-ScriptDependencies
                                         WarningAction = 'SilentlyContinue'
                                         Debug = $DebugPreference
                                     }
+            if ($PSBoundParameters.ContainsKey('Credential'))
+            {
+                $FindScriptArguments.Add('Credential',$Credential)
+            }
 
             if($DependentScriptInfo.ExternalScriptDependencies -contains $requiredScript)
             {

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -13735,10 +13735,10 @@ function Get-PrivateData
     {
         $ReleaseNotesLine = "ReleaseNotes = "+$ReleaseNotes
     }
-    $ExternalModuleDependenciesLine ="# ExternalModuleDependencies = ''"
+    $ExternalModuleDependenciesLine ="# ExternalModuleDependencies = @()"
     if($ExternalModuleDependencies -ne "''")
     {
-        $ExternalModuleDependenciesLine = "ExternalModuleDependencies = "+$ExternalModuleDependencies
+        $ExternalModuleDependenciesLine = "ExternalModuleDependencies = @($ExternalModuleDependencies)"
     }
 
     if(-not $ExtraPropertiesString -eq "")

--- a/PowerShellGet/PowerShellGet.psd1
+++ b/PowerShellGet/PowerShellGet.psd1
@@ -1,6 +1,6 @@
 ﻿@{
 RootModule = 'PSModule.psm1'
-ModuleVersion = '1.1.3.1'
+ModuleVersion = '1.1.3.2'
 GUID = '1d73a601-4a6c-43c5-ba3f-619b18bbb404'
 Author = 'Microsoft Corporation'
 CompanyName = 'Microsoft Corporation'

--- a/PowerShellGet/PowerShellGet.psd1
+++ b/PowerShellGet/PowerShellGet.psd1
@@ -1,6 +1,6 @@
 ﻿@{
 RootModule = 'PSModule.psm1'
-ModuleVersion = '1.1.3.0'
+ModuleVersion = '1.1.3.1'
 GUID = '1d73a601-4a6c-43c5-ba3f-619b18bbb404'
 Author = 'Microsoft Corporation'
 CompanyName = 'Microsoft Corporation'

--- a/Tests/PSGetUpdateScriptInfo.Tests.ps1
+++ b/Tests/PSGetUpdateScriptInfo.Tests.ps1
@@ -1,0 +1,157 @@
+﻿<#####################################################################################
+ # File: PSGetUpdateScriptInfo.Tests.ps1
+ # Tests for PSGet ScriptInfo functionality
+ #
+ # Copyright (c) Microsoft Corporation, 2015
+ #####################################################################################>
+
+<#
+   Name: PowerShell.PSGet.UpdateScriptInfo.Tests
+   Description: Tests for Update-ScriptInfo cmdlet functionality
+
+   Local PSGet Test Gallery (ex: http://localhost:8765/packages) is pre-populated with static scripts:
+        Fabrikam-ClientScript: versions 1.0, 1.5, 2.0, 2.5
+        Fabrikam-ServerScript: versions 1.0, 1.5, 2.0, 2.5
+#>
+
+function SuiteSetup {
+    Import-Module "$PSScriptRoot\PSGetTestUtils.psm1" -WarningAction SilentlyContinue
+    Import-Module "$PSScriptRoot\Asserts.psm1" -WarningAction SilentlyContinue
+
+    $script:ProgramFilesScriptsPath = Get-AllUsersScriptsPath 
+    $script:MyDocumentsScriptsPath = Get-CurrentUserScriptsPath 
+    $script:PSGetLocalAppDataPath = Get-PSGetLocalAppDataPath
+    $script:TempPath = Get-TempPath
+
+    #Bootstrap NuGet binaries
+    Install-NuGetBinaries
+
+    $psgetModuleInfo = Import-Module PowerShellGet -Global -Force -Passthru
+    Import-LocalizedData  script:LocalizedData -filename PSGet.Resource.psd1 -BaseDirectory $psgetModuleInfo.ModuleBase
+
+    $script:moduleSourcesFilePath= Join-Path $script:PSGetLocalAppDataPath "PSRepositories.xml"
+    $script:moduleSourcesBackupFilePath = Join-Path $script:PSGetLocalAppDataPath "PSRepositories.xml_$(get-random)_backup"
+    if(Test-Path $script:moduleSourcesFilePath)
+    {
+        Rename-Item $script:moduleSourcesFilePath $script:moduleSourcesBackupFilePath -Force
+    }
+
+    GetAndSet-PSGetTestGalleryDetails -IsScriptSuite -SetPSGallery
+
+    Get-InstalledScript -Name Fabrikam-ServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
+    Get-InstalledScript -Name Fabrikam-ClientScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
+
+    if($PSEdition -ne 'Core')
+    {
+        $script:userName = "PSGetUser"
+        $password = "Password1"
+        $null = net user $script:userName $password /add
+        $secstr = ConvertTo-SecureString $password -AsPlainText -Force
+        $script:credential = new-object -typename System.Management.Automation.PSCredential -argumentlist $script:userName, $secstr
+    }
+
+    $script:assertTimeOutms = 20000
+    
+    # Create temp folder for saving the scripts
+    $script:TempSavePath="$env:LocalAppData\temp\PSGet_$(Get-Random)"
+    $null = New-Item -Path $script:TempSavePath -ItemType Directory -Force
+
+    $script:AddedAllUsersInstallPath    = Set-PATHVariableForScriptsInstallLocation -Scope AllUsers
+    $script:AddedCurrentUserInstallPath = Set-PATHVariableForScriptsInstallLocation -Scope CurrentUser
+}
+
+function SuiteCleanup {
+    if(Test-Path $script:moduleSourcesBackupFilePath)
+    {
+        Move-Item $script:moduleSourcesBackupFilePath $script:moduleSourcesFilePath -Force
+    }
+    else
+    {
+        RemoveItem $script:moduleSourcesFilePath
+    }
+
+    # Import the PowerShellGet provider to reload the repositories.
+    $null = Import-PackageProvider -Name PowerShellGet -Force
+
+    if($PSEdition -ne 'Core')
+    {
+        # Delete the user
+        net user $script:UserName /delete | Out-Null
+        # Delete the user profile
+        $userProfile = (Get-WmiObject -Class Win32_UserProfile | Where-Object {$_.LocalPath -match $script:UserName})
+        if($userProfile)
+        {
+            RemoveItem $userProfile.LocalPath
+        }
+    }
+    RemoveItem $script:TempSavePath
+
+
+    if($script:AddedAllUsersInstallPath)
+    {
+        Reset-PATHVariableForScriptsInstallLocation -Scope AllUsers
+    }
+
+    if($script:AddedCurrentUserInstallPath)
+    {
+        Reset-PATHVariableForScriptsInstallLocation -Scope CurrentUser
+    }
+}
+
+$ScriptFileInfoProperties = @{
+	Version='1.2.3.4'
+	Author='john@fabrikam.com'
+	Guid='cb0ec9a8-b1a8-4701-8b85-3e9a8341eba4'
+	Description='Test Script Description'
+	PrivateData='ScriptControlInfo=1.2.3.4.5abcd'
+	CompanyName='Fabrikam'
+	Copyright='@R'
+	RequiredModules='PowerShellGet'
+	ExternalModuleDependencies='PowerShellGet'
+	RequiredScripts='Fabrikam-ServerScript2'
+	ExternalScriptDependencies='Fabrikam-ServerScript2'
+	Tags='Tag1','Tag2'
+	ProjectUri='https://www.fabrikam-psprojects.com/'
+	LicenseUri='https://www.fabrikam-pslicense.com/'
+	IconUri='https://www.fabrikam-psicon.com/'
+	ReleaseNotes='Test Script version 1.2.3.4'
+}
+
+Describe "Update Existing Script Info" -tag CI {
+
+    BeforeAll {
+        SuiteSetup
+    }
+
+    AfterAll {
+        SuiteCleanup
+    }
+
+    AfterEach {
+        Get-InstalledScript -Name Fabrikam-ServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
+        Get-InstalledScript -Name Fabrikam-ClientScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
+    }
+
+    # Purpose: UpdateScriptWithConfirmAndNoToPrompt
+    #
+    # Action: Update-Script Fabrikam-ServerScript -Confirm
+    #
+    # Expected Result: script should not be updated after confirming NO
+    #
+ 
+    It "UpdateScriptFileInfo" {
+        $scriptName = 'Fabrikam-ServerScript'
+        Install-Script $scriptName -Scope AllUsers
+		$Script = Get-InstalledScript -Name $scriptName
+		$ScriptFilePath = Join-Path -Path $script.InstalledLocation -ChildPath "$scriptName.ps1"
+
+        Update-ScriptFileInfo -Path $ScriptFilePath @ScriptFileInfoProperties
+		$ScriptFileInfo = Test-ScriptFileInfo -Path $ScriptFilePath
+		foreach ($Prop in $ScriptFileInfoProperties.Keys)
+		{
+			It "Test $Prop" {
+				$ScriptFileInfo.$Prop | Should be $ScriptFileInfoProperties[$Prop]
+			}
+		}
+    }
+}


### PR DESCRIPTION
Bug fix: Update-ModuleManifest -PrivateData @{ExternalModuleDependencies='SomeModule'} should write the ExternalModuleDependencies as @() in the ModuleManifest`s Private Data, otherwise Publish-Module fails to detect it properly