### PR TITLE
Bug fix: Update-ModuleManifest -PrivateData @{ExternalModuleDependencies='SomeModule'} should write the ExternalModuleDependencies as @() in the ModuleManifest`s Private Data

### DIFF
--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -13735,10 +13735,10 @@ function Get-PrivateData
     {
         $ReleaseNotesLine = "ReleaseNotes = "+$ReleaseNotes
     }
-    $ExternalModuleDependenciesLine ="# ExternalModuleDependencies = ''"
+    $ExternalModuleDependenciesLine ="# ExternalModuleDependencies = @()"
     if($ExternalModuleDependencies -ne "''")
     {
-        $ExternalModuleDependenciesLine = "ExternalModuleDependencies = "+$ExternalModuleDependencies
+        $ExternalModuleDependenciesLine = "ExternalModuleDependencies = @($ExternalModuleDependencies)"
     }
 
     if(-not $ExtraPropertiesString -eq "")

--- a/PowerShellGet/PowerShellGet.psd1
+++ b/PowerShellGet/PowerShellGet.psd1
@@ -1,6 +1,6 @@
 ﻿@{
 RootModule = 'PSModule.psm1'
-ModuleVersion = '1.1.3.1'
+ModuleVersion = '1.1.3.2'
 GUID = '1d73a601-4a6c-43c5-ba3f-619b18bbb404'
 Author = 'Microsoft Corporation'
 CompanyName = 'Microsoft Corporation'


### PR DESCRIPTION
Bug fix: Update-ModuleManifest -PrivateData @{ExternalModuleDependencies='SomeModule'} should write the ExternalModuleDependencies as @() in the ModuleManifest`s Private Data, otherwise Publish-Module fails to detect it properly