### PR TITLE
Disable PowerShellGet Telemetry on PowerShell Core 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.3.2
+* Disabled PowerShellGet Telemetry on PS Core as PowerShell Telemetry APIs got removed in PowerShell Core beta builds. (#153)
+* Fixed for DateTime format serialization issue. (#141)
+* Update-ModuleManifest should add ExternalModuleDependencies value as a collection. (#129)
+
+
 ## 1.1.3.1
 
 New features

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -432,66 +432,20 @@ Microsoft.PowerShell.Utility\Import-LocalizedData  LocalizedData -filename PSGet
 
 #region Add .Net type for Telemetry APIs and WebProxy
 
-# This code is required to add a .Net type and call the Telemetry APIs 
-# This is required since PowerShell does not support generation of .Net Anonymous types
-#
-$requiredAssembly = @( [System.Net.IWebProxy].Assembly.FullName, 
-                       [System.Uri].Assembly.FullName )
-
-if(-not $script:IsCoreCLR) {
-    $requiredAssembly += [System.Management.Automation.PSCmdlet].Assembly.FullName
-}
-                       
-$script:IsSafeX509ChainHandleAvailable = ($null -ne ('Microsoft.Win32.SafeHandles.SafeX509ChainHandle' -as [Type]))
-
-if($script:IsSafeX509ChainHandleAvailable)
-{  
-   # It is not possible to define a single internal SafeHandle class in PowerShellGet namespace for all the supported versions of .Net Framework including .Net Core.
-   # SafeHandleZeroOrMinusOneIsInvalid is not a public class on .Net Core,
-   # therefore SafeX509ChainHandle will be used if it is available otherwise InternalSafeX509ChainHandle is defined below.
-   #
-   # ChainContext is not available on .Net Core, we must have to use SafeX509ChainHandle on .Net Core.
-   #
-   $SafeX509ChainHandleClassName = 'SafeX509ChainHandle'      
-   $requiredAssembly += [Microsoft.Win32.SafeHandles.SafeX509ChainHandle].Assembly.FullName
-}
-else
+# Check and add InternalWebProxy type
+if( -not ('Microsoft.PowerShell.Commands.PowerShellGet.InternalWebProxy' -as [Type]))
 {
-   # SafeX509ChainHandle is not available on .Net Framework 4.5 or older versions,
-   # therefore InternalSafeX509ChainHandle is defined below.
-   #
-   $SafeX509ChainHandleClassName = 'InternalSafeX509ChainHandle'
-}
+    $RequiredAssembliesForInternalWebProxy = @( 
+        [System.Net.IWebProxy].Assembly.FullName,
+        [System.Uri].Assembly.FullName
+    )
 
-$source = @" 
+    $InternalWebProxySource = @'
 using System; 
 using System.Net;
-using System.Management.Automation;
-using Microsoft.Win32.SafeHandles;
-using System.Security.Cryptography;
-using System.Runtime.InteropServices;
-using System.Runtime.ConstrainedExecution;
-using System.Runtime.Versioning;
-using System.Security;
 
 namespace Microsoft.PowerShell.Commands.PowerShellGet 
-{ 
-$(if(-not $script:IsCoreCLR) {
-    '
-    public static class Telemetry  
-    { 
-        public static void TraceMessageArtifactsNotFound(string[] artifactsNotFound, string operationName) 
-        { 
-            Microsoft.PowerShell.Telemetry.Internal.TelemetryAPI.TraceMessage(operationName, new { ArtifactsNotFound = artifactsNotFound });
-        }
-        
-        public static void TraceMessageNonPSGalleryRegistration(string sourceLocationType, string sourceLocationHash, string installationPolicy, string packageManagementProvider, string publishLocationHash, string scriptSourceLocationHash, string scriptPublishLocationHash, string operationName) 
-        { 
-            Microsoft.PowerShell.Telemetry.Internal.TelemetryAPI.TraceMessage(operationName, new { SourceLocationType = sourceLocationType, SourceLocationHash = sourceLocationHash, InstallationPolicy = installationPolicy, PackageManagementProvider = packageManagementProvider, PublishLocationHash = publishLocationHash, ScriptSourceLocationHash = scriptSourceLocationHash, ScriptPublishLocationHash = scriptPublishLocationHash });
-        }        
-    }
-    '
-})
+{        
     /// <summary>
     /// Used by Ping-Endpoint function to supply webproxy to HttpClient
     /// We cannot use System.Net.WebProxy because this is not available on CoreClr
@@ -531,8 +485,120 @@ $(if(-not $script:IsCoreCLR) {
         {
             return false;
         }
-    } 
+    }
+}
+'@
 
+    try
+    {
+        $AddType_prams = @{
+            TypeDefinition = $InternalWebProxySource
+            Language = 'CSharp'
+            ErrorAction = 'SilentlyContinue'
+        }
+        if (-not $script:IsCoreCLR)
+        {
+            $AddType_prams['ReferencedAssemblies'] = $RequiredAssembliesForInternalWebProxy
+        }
+        Add-Type @AddType_prams 
+    }
+    catch
+    {
+        Write-Warning -Message "InternalWebProxy: $_"
+    }
+}
+
+# Check and add Telemetry type
+if(-not $script:IsCoreCLR -and 
+   -not ('Microsoft.PowerShell.Commands.PowerShellGet.Telemetry' -as [Type]))
+{
+    $RequiredAssembliesForTelemetry = @( 
+        [System.Management.Automation.PSCmdlet].Assembly.FullName
+    )
+
+    $TelemetrySource = @'
+using System; 
+using System.Management.Automation;
+
+namespace Microsoft.PowerShell.Commands.PowerShellGet 
+{ 
+    public static class Telemetry  
+    { 
+        public static void TraceMessageArtifactsNotFound(string[] artifactsNotFound, string operationName) 
+        { 
+            Microsoft.PowerShell.Telemetry.Internal.TelemetryAPI.TraceMessage(operationName, new { ArtifactsNotFound = artifactsNotFound });
+        }
+        
+        public static void TraceMessageNonPSGalleryRegistration(string sourceLocationType, string sourceLocationHash, string installationPolicy, string packageManagementProvider, string publishLocationHash, string scriptSourceLocationHash, string scriptPublishLocationHash, string operationName) 
+        { 
+            Microsoft.PowerShell.Telemetry.Internal.TelemetryAPI.TraceMessage(operationName, new { SourceLocationType = sourceLocationType, SourceLocationHash = sourceLocationHash, InstallationPolicy = installationPolicy, PackageManagementProvider = packageManagementProvider, PublishLocationHash = publishLocationHash, ScriptSourceLocationHash = scriptSourceLocationHash, ScriptPublishLocationHash = scriptPublishLocationHash });
+        }        
+    }
+}
+'@
+
+    try
+    {
+        $AddType_prams = @{
+            TypeDefinition = $TelemetrySource
+            Language = 'CSharp'
+            ErrorAction = 'SilentlyContinue'
+        }
+        $AddType_prams['ReferencedAssemblies'] = $RequiredAssembliesForTelemetry
+        Add-Type @AddType_prams
+    }
+    catch
+    {
+        Write-Warning -Message "Telemetry: $_"
+    }
+}
+# Turn ON Telemetry if the infrastructure is present on the machine
+$script:TelemetryEnabled = $false
+if('Microsoft.PowerShell.Commands.PowerShellGet.Telemetry' -as [Type])
+{
+    $telemetryMethods = ([Microsoft.PowerShell.Commands.PowerShellGet.Telemetry] | Get-Member -Static).Name
+    if ($telemetryMethods.Contains("TraceMessageArtifactsNotFound") -and $telemetryMethods.Contains("TraceMessageNonPSGalleryRegistration"))
+    {
+        $script:TelemetryEnabled = $true
+    }
+}
+
+# Check and add Win32Helpers type
+$script:IsSafeX509ChainHandleAvailable = ($null -ne ('Microsoft.Win32.SafeHandles.SafeX509ChainHandle' -as [Type]))
+if($script:IsWindows -and -not ('Microsoft.PowerShell.Commands.PowerShellGet.Win32Helpers' -as [Type]))
+{
+    $RequiredAssembliesForWin32Helpers = @()
+    if($script:IsSafeX509ChainHandleAvailable)
+    {  
+        # It is not possible to define a single internal SafeHandle class in PowerShellGet namespace for all the supported versions of .Net Framework including .Net Core.
+        # SafeHandleZeroOrMinusOneIsInvalid is not a public class on .Net Core,
+        # therefore SafeX509ChainHandle will be used if it is available otherwise InternalSafeX509ChainHandle is defined below.
+        #
+        # ChainContext is not available on .Net Core, we must have to use SafeX509ChainHandle on .Net Core.
+        #
+        $SafeX509ChainHandleClassName = 'SafeX509ChainHandle'      
+        $RequiredAssembliesForWin32Helpers += [Microsoft.Win32.SafeHandles.SafeX509ChainHandle].Assembly.FullName
+    }
+    else
+    {
+        # SafeX509ChainHandle is not available on .Net Framework 4.5 or older versions,
+        # therefore InternalSafeX509ChainHandle is defined below.
+        #
+        $SafeX509ChainHandleClassName = 'InternalSafeX509ChainHandle'
+    }
+
+    $Win32HelpersSource = @" 
+using System; 
+using System.Net;
+using Microsoft.Win32.SafeHandles;
+using System.Security.Cryptography;
+using System.Runtime.InteropServices;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.Versioning;
+using System.Security;
+
+namespace Microsoft.PowerShell.Commands.PowerShellGet 
+{ 
     [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)]
     public struct CERT_CHAIN_POLICY_PARA {
         public CERT_CHAIN_POLICY_PARA(int size) {
@@ -713,37 +779,22 @@ $(if($script:IsSafeX509ChainHandleAvailable)
 } 
 "@ 
 
-if( -not ('Microsoft.PowerShell.Commands.PowerShellGet.InternalWebProxy' -as [Type]) -and
-    $script:IsWindows)
-{
     try
     {
         $AddType_prams = @{
-            TypeDefinition = $source
+            TypeDefinition = $Win32HelpersSource
             Language = 'CSharp'            
             ErrorAction = 'SilentlyContinue'
         }
-        if (-not $script:IsCoreCLR)
+        if (-not $script:IsCoreCLR -and $RequiredAssembliesForWin32Helpers)
         {
-            $AddType_prams['ReferencedAssemblies'] = $requiredAssembly
+            $AddType_prams['ReferencedAssemblies'] = $RequiredAssembliesForWin32Helpers
         }
-        Add-Type @AddType_prams 
+        Add-Type @AddType_prams
     }
     catch
     {
-        Write-Warning -Message $_
-    }
-}
-
-# Turn ON Telemetry if the infrastructure is present on the machine
-$script:TelemetryEnabled = $false
-if('Microsoft.PowerShell.Commands.PowerShellGet.Telemetry' -as [Type])
-{
-    $telemetryMethods = ([Microsoft.PowerShell.Commands.PowerShellGet.Telemetry] | Get-Member -Static).Name
-
-    if ($telemetryMethods.Contains("TraceMessageArtifactsNotFound") -and $telemetryMethods.Contains("TraceMessageNonPSGalleryRegistration"))
-    {
-        $script:TelemetryEnabled = $true
+        Write-Warning -Message "Win32Helpers: $_"
     }
 }
 

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -509,7 +509,7 @@ namespace Microsoft.PowerShell.Commands.PowerShellGet
 }
 
 # Check and add Telemetry type
-if(-not $script:IsCoreCLR -and 
+if(('Microsoft.PowerShell.Telemetry.Internal.TelemetryAPI' -as [Type]) -and
    -not ('Microsoft.PowerShell.Commands.PowerShellGet.Telemetry' -as [Type]))
 {
     $RequiredAssembliesForTelemetry = @( 

--- a/PowerShellGet/PowerShellGet.psd1
+++ b/PowerShellGet/PowerShellGet.psd1
@@ -55,6 +55,11 @@ PrivateData = @{
         ProjectUri = 'https://go.microsoft.com/fwlink/?LinkId=828955'
         LicenseUri = 'https://go.microsoft.com/fwlink/?LinkId=829061'
         ReleaseNotes = @'
+## 1.1.3.2
+* Disabled PowerShellGet Telemetry on PS Core as PowerShell Telemetry APIs got removed in PowerShell Core beta builds. (#153)
+* Fixed for DateTime format serialization issue. (#141)
+* Update-ModuleManifest should add ExternalModuleDependencies value as a collection. (#129)
+
 ## 1.1.3.1
 
 New features

--- a/Tests/PowerShellGet.Tests.ps1
+++ b/Tests/PowerShellGet.Tests.ps1
@@ -1,8 +1,13 @@
-﻿$RepositoryName = 'INTGallery'
+﻿# no progress output during these tests
+$ProgressPreference = "SilentlyContinue"
+
+$RepositoryName = 'INTGallery'
 $SourceLocation = 'https://dtlgalleryint.cloudapp.net'
 $RegisteredINTRepo = $false
 $ContosoServer = 'ContosoServer'
 $FabrikamServerScript = 'Fabrikam-ServerScript'
+$Initialized = $false
+
 
 #region Utility functions
 
@@ -37,7 +42,7 @@ if(IsInbox)
     $script:MyDocumentsPSPath = if($script:MyDocumentsFolderPath)
                                 {
                                     Microsoft.PowerShell.Management\Join-Path -Path $script:MyDocumentsFolderPath -ChildPath "WindowsPowerShell"
-                                } 
+                                }
                                 else
                                 {
                                     Microsoft.PowerShell.Management\Join-Path -Path $env:USERPROFILE -ChildPath "Documents\WindowsPowerShell"
@@ -62,43 +67,49 @@ $script:MyDocumentsScriptsPath = Microsoft.PowerShell.Management\Join-Path -Path
 
 #region Register a test repository
 
-$repo = Get-PSRepository -ErrorAction SilentlyContinue | 
-            Where-Object {$_.SourceLocation.StartsWith($SourceLocation, [System.StringComparison]::OrdinalIgnoreCase)}
-if($repo)
+function Initialize
 {
-    $RepositoryName = $repo.Name
-}
-else
-{
-    Register-PSRepository -Name $RepositoryName -SourceLocation $SourceLocation -InstallationPolicy Trusted
-    $RegisteredINTRepo = $true
+    # Cleaned up commands whose output to console by deleting or piping to Out-Null
+    Import-Module PackageManagement
+    Get-PackageProvider -ListAvailable | Out-Null
+
+    $repo = Get-PSRepository -ErrorAction SilentlyContinue |
+                Where-Object {$_.SourceLocation.StartsWith($SourceLocation, [System.StringComparison]::OrdinalIgnoreCase)}
+    if($repo)
+    {
+        $script:RepositoryName = $repo.Name
+    }
+    else
+    {
+        Register-PSRepository -Name $RepositoryName -SourceLocation $SourceLocation -InstallationPolicy Trusted
+        $script:RegisteredINTRepo = $true
+    }
 }
 
 #endregion
 
-Describe "PowerShellGet - Module tests" -tags "CI" {
+function Remove-InstalledModules
+{
+    Get-InstalledModule -Name $ContosoServer -AllVersions -ErrorAction SilentlyContinue | Uninstall-Module -Force
+}
+
+Describe "PowerShellGet - Module tests" -tags "Feature" {
+
+    BeforeAll {
+        if ($script:Initialized -eq $false) {
+            Initialize
+            $script:Initialized = $true
+        }
+    }
 
     BeforeEach {
-        Get-InstalledModule -Name $ContosoServer -AllVersions -ErrorAction SilentlyContinue | PowerShellGet\Uninstall-Module -Force
+        Remove-InstalledModules
     }
 
     It "Should find a module correctly" {
         $psgetModuleInfo = Find-Module -Name $ContosoServer -Repository $RepositoryName
         $psgetModuleInfo.Name | Should Be $ContosoServer
         $psgetModuleInfo.Repository | Should Be $RepositoryName
-    }
-
-    It "Should install a module correctly to the required location with default AllUsers scope" {
-        Install-Module -Name $ContosoServer -Repository $RepositoryName
-        $installedModuleInfo = Get-InstalledModule -Name $ContosoServer
-
-        $installedModuleInfo | Should Not Be $null        
-        $installedModuleInfo.Name | Should Be $ContosoServer
-        $installedModuleInfo.InstalledLocation.StartsWith($script:programFilesModulesPath, [System.StringComparison]::OrdinalIgnoreCase) | Should Be $true
-
-        $module = Get-Module $ContosoServer -ListAvailable
-        $module.Name | Should be $ContosoServer
-        $module.ModuleBase | Should Be $installedModuleInfo.InstalledLocation
     }
 
     It "Should install a module correctly to the required location with CurrentUser scope" {
@@ -115,29 +126,63 @@ Describe "PowerShellGet - Module tests" -tags "CI" {
     }
 
     AfterAll {
-        Get-InstalledModule -Name $ContosoServer -AllVersions -ErrorAction SilentlyContinue | PowerShellGet\Uninstall-Module -Force
+        Remove-InstalledModules
     }
 }
 
-Describe "PowerShellGet - Script tests" -tags "CI" {
+Describe "PowerShellGet - Module tests (Admin)" -tags @('Feature', 'RequireAdminOnWindows') {
+
+    BeforeAll {
+        if ($script:Initialized -eq $false) {
+            Initialize
+            $script:Initialized = $true
+        }
+    }
 
     BeforeEach {
-        Get-InstalledScript -Name $FabrikamServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
+        Remove-InstalledModules
+    }
+
+    It "Should install a module correctly to the required location with default AllUsers scope" {
+        Install-Module -Name $ContosoServer -Repository $RepositoryName
+        $installedModuleInfo = Get-InstalledModule -Name $ContosoServer
+
+        $installedModuleInfo | Should Not Be $null
+        $installedModuleInfo.Name | Should Be $ContosoServer
+        $installedModuleInfo.InstalledLocation.StartsWith($script:programFilesModulesPath, [System.StringComparison]::OrdinalIgnoreCase) | Should Be $true
+
+        $module = Get-Module $ContosoServer -ListAvailable
+        $module.Name | Should be $ContosoServer
+        $module.ModuleBase | Should Be $installedModuleInfo.InstalledLocation
+    }
+
+    AfterAll {
+        Remove-InstalledModules
+    }
+}
+
+function Remove-InstalledScripts
+{
+    Get-InstalledScript -Name $FabrikamServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
+}
+
+Describe "PowerShellGet - Script tests" -tags "Feature" {
+
+    BeforeAll {
+        if ($script:Initialized -eq $false) {
+            Initialize
+            $script:Initialized = $true
+        }
+    }
+
+    BeforeEach {
+        Remove-InstalledScripts
     }
 
     It "Should find a script correctly" {
         $psgetScriptInfo = Find-Script -Name $FabrikamServerScript -Repository $RepositoryName
         $psgetScriptInfo.Name | Should Be $FabrikamServerScript
         $psgetScriptInfo.Repository | Should Be $RepositoryName
-    }
-
-    It "Should install a script correctly to the required location with default AllUsers scope" {
-        Install-Script -Name $FabrikamServerScript -Repository $RepositoryName -NoPathUpdate
-        $installedScriptInfo = Get-InstalledScript -Name $FabrikamServerScript
-
-        $installedScriptInfo | Should Not Be $null
-        $installedScriptInfo.Name | Should Be $FabrikamServerScript
-        $installedScriptInfo.InstalledLocation.StartsWith($script:ProgramFilesScriptsPath, [System.StringComparison]::OrdinalIgnoreCase) | Should Be $true
     }
 
     It "Should install a script correctly to the required location with CurrentUser scope" {
@@ -150,7 +195,62 @@ Describe "PowerShellGet - Script tests" -tags "CI" {
     }
 
     AfterAll {
-        Get-InstalledScript -Name $FabrikamServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
+        Remove-InstalledScripts
+    }
+}
+
+Describe "PowerShellGet - Script tests (Admin)" -tags @('Feature', 'RequireAdminOnWindows') {
+
+    BeforeAll {
+        if ($script:Initialized -eq $false) {
+            Initialize
+            $script:Initialized = $true
+        }
+    }
+
+    BeforeEach {
+        Remove-InstalledScripts
+    }
+
+    It "Should install a script correctly to the required location with default AllUsers scope" {
+        Install-Script -Name $FabrikamServerScript -Repository $RepositoryName -NoPathUpdate
+        $installedScriptInfo = Get-InstalledScript -Name $FabrikamServerScript
+
+        $installedScriptInfo | Should Not Be $null
+        $installedScriptInfo.Name | Should Be $FabrikamServerScript
+        $installedScriptInfo.InstalledLocation.StartsWith($script:ProgramFilesScriptsPath, [System.StringComparison]::OrdinalIgnoreCase) | Should Be $true
+    }
+
+    AfterAll {
+        Remove-InstalledScripts
+    }
+}
+
+Describe 'PowerShellGet Type tests' -tags @('BVT','CI') {
+    BeforeAll {
+        Import-Module PowerShellGet -Force
+    }
+
+    It 'Ensure PowerShellGet Types are available' {
+        $PowerShellGetNamespace = 'Microsoft.PowerShell.Commands.PowerShellGet'
+        $PowerShellGetTypeDetails = @{
+            InternalWebProxy = @('GetProxy', 'IsBypassed')
+            CERT_CHAIN_POLICY_PARA = @('cbSize','dwFlags','pvExtraPolicyPara')
+            CERT_CHAIN_POLICY_STATUS = @('cbSize','dwError','lChainIndex','lElementIndex','pvExtraPolicyStatus')
+            InternalSafeHandleZeroOrMinusOneIsInvalid = @('IsInvalid')
+            InternalSafeX509ChainHandle = @('CertFreeCertificateChain','ReleaseHandle','InvalidHandle')
+            Win32Helpers = @('CertVerifyCertificateChainPolicy', 'CertDuplicateCertificateChain', 'IsMicrosoftCertificate')
+        }
+        if(-not $Script:IsCoreCLR) {
+            $PowerShellGetTypeDetails['Telemetry'] = @('TraceMessageArtifactsNotFound', 'TraceMessageNonPSGalleryRegistration')
+        }
+
+        $PowerShellGetTypeDetails.GetEnumerator() | ForEach-Object {
+            $ClassName = $_.Name
+            $Type = "$PowerShellGetNamespace.$ClassName" -as [Type]
+            $Type | Select-Object -ExpandProperty Name | Should Be $ClassName
+            $_.Value | ForEach-Object { $Type.DeclaredMembers.Name -contains $_ | Should Be $true }
+        }
     }
 }
 

--- a/Tests/PowerShellGet.Tests.ps1
+++ b/Tests/PowerShellGet.Tests.ps1
@@ -235,13 +235,17 @@ Describe 'PowerShellGet Type tests' -tags @('BVT','CI') {
         $PowerShellGetNamespace = 'Microsoft.PowerShell.Commands.PowerShellGet'
         $PowerShellGetTypeDetails = @{
             InternalWebProxy = @('GetProxy', 'IsBypassed')
-            CERT_CHAIN_POLICY_PARA = @('cbSize','dwFlags','pvExtraPolicyPara')
-            CERT_CHAIN_POLICY_STATUS = @('cbSize','dwError','lChainIndex','lElementIndex','pvExtraPolicyStatus')
-            InternalSafeHandleZeroOrMinusOneIsInvalid = @('IsInvalid')
-            InternalSafeX509ChainHandle = @('CertFreeCertificateChain','ReleaseHandle','InvalidHandle')
-            Win32Helpers = @('CertVerifyCertificateChainPolicy', 'CertDuplicateCertificateChain', 'IsMicrosoftCertificate')
         }
-        if(-not $Script:IsCoreCLR) {
+
+        if((IsWindows) -and ($PSVersionTable.PSVersion -ge '5.1.0')) {
+            $PowerShellGetTypeDetails['CERT_CHAIN_POLICY_PARA'] = @('cbSize','dwFlags','pvExtraPolicyPara')
+            $PowerShellGetTypeDetails['CERT_CHAIN_POLICY_STATUS'] = @('cbSize','dwError','lChainIndex','lElementIndex','pvExtraPolicyStatus')
+            $PowerShellGetTypeDetails['InternalSafeHandleZeroOrMinusOneIsInvalid'] = @('IsInvalid')
+            $PowerShellGetTypeDetails['InternalSafeX509ChainHandle'] = @('CertFreeCertificateChain','ReleaseHandle','InvalidHandle')
+            $PowerShellGetTypeDetails['Win32Helpers'] = @('CertVerifyCertificateChainPolicy', 'CertDuplicateCertificateChain', 'IsMicrosoftCertificate')
+        }
+
+        if(-not (IsCoreCLR)) {
             $PowerShellGetTypeDetails['Telemetry'] = @('TraceMessageArtifactsNotFound', 'TraceMessageNonPSGalleryRegistration')
         }
 

--- a/Tests/PowerShellGet.Tests.ps1
+++ b/Tests/PowerShellGet.Tests.ps1
@@ -237,7 +237,7 @@ Describe 'PowerShellGet Type tests' -tags @('BVT','CI') {
             InternalWebProxy = @('GetProxy', 'IsBypassed')
         }
 
-        if((IsWindows) -and ($PSVersionTable.PSVersion -ge '5.1.0')) {
+        if((IsWindows)) {
             $PowerShellGetTypeDetails['CERT_CHAIN_POLICY_PARA'] = @('cbSize','dwFlags','pvExtraPolicyPara')
             $PowerShellGetTypeDetails['CERT_CHAIN_POLICY_STATUS'] = @('cbSize','dwError','lChainIndex','lElementIndex','pvExtraPolicyStatus')
             $PowerShellGetTypeDetails['InternalSafeHandleZeroOrMinusOneIsInvalid'] = @('IsInvalid')
@@ -245,7 +245,7 @@ Describe 'PowerShellGet Type tests' -tags @('BVT','CI') {
             $PowerShellGetTypeDetails['Win32Helpers'] = @('CertVerifyCertificateChainPolicy', 'CertDuplicateCertificateChain', 'IsMicrosoftCertificate')
         }
 
-        if(-not (IsCoreCLR)) {
+        if('Microsoft.PowerShell.Telemetry.Internal.TelemetryAPI' -as [Type]) {
             $PowerShellGetTypeDetails['Telemetry'] = @('TraceMessageArtifactsNotFound', 'TraceMessageNonPSGalleryRegistration')
         }
 

--- a/tools/download.sh
+++ b/tools/download.sh
@@ -9,7 +9,7 @@ trap '
 
 get_url() {
     fork=$2
-    release=v6.0.0-beta.1
+    release=v6.0.0-beta.5
     echo "https://github.com/$fork/PowerShell/releases/download/$release/$1"
 }
 
@@ -26,7 +26,7 @@ case "$OSTYPE" in
                     sudo yum install -y curl
                 fi
 
-                package=powershell-6.0.0_beta.1-1.el7.centos.x86_64.rpm
+                package=powershell-6.0.0_beta.5-1.el7.x86_64.rpm
                 ;;
             ubuntu)
                 if ! hash curl 2>/dev/null; then
@@ -36,10 +36,10 @@ case "$OSTYPE" in
 
                 case "$VERSION_ID" in
                     14.04)
-                        package=powershell_6.0.0-beta.1-1ubuntu1.14.04.1_amd64.deb
+                        package=powershell_6.0.0-beta.5-1ubuntu1.14.04.1_amd64.deb
                         ;;
                     16.04)
-                        package=powershell_6.0.0-beta.1-1ubuntu1.16.04.1_amd64.deb
+                        package=powershell_6.0.0-beta.5-1ubuntu1.16.04.1_amd64.deb
                         ;;
                     *)
                         echo "Ubuntu $VERSION_ID is not supported!" >&2
@@ -55,7 +55,7 @@ case "$OSTYPE" in
                 
                 case "$VERSION_ID" in
                     42.1)
-                        package=powershell-6.0.0_beta.1-1.suse.42.1.x86_64.rpm
+                        package=powershell-6.0.0_beta.5-1.suse.42.1.x86_64.rpm
                         ;;
                     *)
                         echo "OpenSUSE $VERSION_ID is not supported!" >&2
@@ -69,7 +69,7 @@ case "$OSTYPE" in
         ;;
     darwin*)
         # We don't check for curl as macOS should have a system version
-        package=powershell-6.0.0-beta.1-osx.10.12-x64.pkg
+        package=powershell-6.0.0-beta.5-osx.10.12-x64.pkg
         ;;
     *)
         echo "$OSTYPE is not supported!" >&2


### PR DESCRIPTION
- Disabled PowerShellGet Telemetry on PS Core as PowerShell Telemetry APIs got removed in PowerShell Core beta builds.
- Added unit tests for validating the availablity of PowerShellGet types.
- Updated download.sh for latest beta build version.