### PR TITLE
Fixed empty version tag for Nuget bug (#156)

### DIFF
--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -8411,7 +8411,14 @@ function Publish-PSArtifactUtility
             $VersionString = "$($Dependency.MinimumVersion)"
         }
 
-        $dependencies += "<dependency id='$($ModuleName)' version='$($VersionString)' />"
+        if ([System.string]::IsNullOrWhiteSpace($VersionString))
+        {
+            $dependencies += "<dependency id='$($ModuleName)'/>"
+        }
+        else 
+        {
+            $dependencies += "<dependency id='$($ModuleName)' version='$($VersionString)' />"
+        }
     }
     
     # Populate the nuspec elements


### PR DESCRIPTION
Updated generate nuget tag code to do not provide version tag for empty or null versioning dependency modules/scripts.
Resolves #156 .