### PR TITLE
Added version for REQUIREDSCRIPTS

### DIFF
--- a/PowerShellGet/PSGet.Resource.psd1
+++ b/PowerShellGet/PSGet.Resource.psd1
@@ -246,8 +246,8 @@ ConvertFrom-StringData @'
         InvalidValueBoolean=The specified value '{0}' for the parameter '{1}' is invalid. It should be $true or $false.
         UserDeclinedLicenseAcceptance=User declined license acceptance.
         AcceptLicense=License Acceptance
-        RequiredScriptVersion=Required version of required script '{0}' is '{1}'
-        FailedToParseRequiredScripts=Cannot parse requiredscripts '{0}'. Acceptable format is <ScriptName> or <ScriptName>:<Minimum Version>
+        RequiredScriptVersion=REQUIREDSCRIPTS: Required version of script '{0}' is '{1}'.
+        FailedToParseRequiredScripts=Cannot parse REQUIREDSCRIPTS '{0}'. Acceptable formats are: <ScriptName> or <ScriptName>:<Minimum Version>.
 ###PSLOC
 '@
 

--- a/PowerShellGet/PSGet.Resource.psd1
+++ b/PowerShellGet/PSGet.Resource.psd1
@@ -247,6 +247,7 @@ ConvertFrom-StringData @'
         UserDeclinedLicenseAcceptance=User declined license acceptance.
         AcceptLicense=License Acceptance
         RequiredScriptVersion=Required version of required script '{0}' is '{1}'
+        FailedToParseRequiredScripts=Cannot parse requiredscripts '{0}'. Acceptable format is <ScriptName> or <ScriptName>:<Minimum Version>
 ###PSLOC
 '@
 

--- a/PowerShellGet/PSGet.Resource.psd1
+++ b/PowerShellGet/PSGet.Resource.psd1
@@ -246,6 +246,7 @@ ConvertFrom-StringData @'
         InvalidValueBoolean=The specified value '{0}' for the parameter '{1}' is invalid. It should be $true or $false.
         UserDeclinedLicenseAcceptance=User declined license acceptance.
         AcceptLicense=License Acceptance
+        RequiredScriptVersion=Required version of required script '{0}' is '{1}'
 ###PSLOC
 '@
 

--- a/PowerShellGet/PSGet.Resource.psd1
+++ b/PowerShellGet/PSGet.Resource.psd1
@@ -247,7 +247,9 @@ ConvertFrom-StringData @'
         UserDeclinedLicenseAcceptance=User declined license acceptance.
         AcceptLicense=License Acceptance
         RequiredScriptVersion=REQUIREDSCRIPTS: Required version of script '{0}' is '{1}'.
-        FailedToParseRequiredScripts=Cannot parse REQUIREDSCRIPTS '{0}'. Acceptable formats are: <ScriptName> or <ScriptName>:<Minimum Version>.
+        RequiredScriptVersoinFormat=<ScriptName>, <ScriptName>:<MinimumVersion>, <ScriptName>:[<RequiredVersion>], <ScriptName>:[<MinimumVersion>,<MaximumVersion>], <ScriptName>:[,<MaximumVersion>]
+        FailedToParseRequiredScripts=Cannot parse REQUIREDSCRIPTS '{0}'. Acceptable formats are: '{1}'.
+        FailedToParseRequiredScriptsVersion=Version format error: {0}, '{1}'. Acceptable formats are: '{2}'. 
 ###PSLOC
 '@
 

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -7822,20 +7822,24 @@ function ValidateAndGet-ScriptDependencies
                                         Debug = $DebugPreference
                                     }
             $ReqScriptInfo = @{}
-            $scriptName = $requiredScript
-            $scriptVersion = [string]::Empty
 
             if ($PSBoundParameters.ContainsKey('Credential'))
             {
                 $FindScriptArguments.Add('Credential',$Credential)
             }
             
-            if ($scriptName.indexOf(';') -gt 0)
+            if (-not ($scriptName -match '^((?<Name>[^:]+)(:(?<Version>[^:]+))?)$'))
             {
-                $scriptName = $requiredScript.Substring(0, $requiredScript.indexOf(';'))
-                $scriptVersion = $requiredScript.Substring($requiredScript.indexOf(';') + 1, $requiredScript.Length - $requiredScript.indexOf(';') - 1)
+                $message = $LocalizedData.FailedToParseRequiredScripts -f ($scriptName)
+                ThrowError -ExceptionName "System.ArgumentException" `
+                            -ExceptionMessage $message `
+                            -ErrorId "FailedToParseRequiredScripts" `
+                            -CallerPSCmdlet $CallerPSCmdlet `
+                            -ErrorCategory InvalidOperation
             }
 
+            $scriptName = $matches['Name']
+            $scriptVersion = $matches['Version']
             if ($DependentScriptInfo.ExternalScriptDependencies -contains $scriptName)
             {
                 Write-Verbose -Message ($LocalizedData.SkippedScriptDependency -f $scriptName)

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -7828,14 +7828,16 @@ function ValidateAndGet-ScriptDependencies
                 $FindScriptArguments.Add('Credential',$Credential)
             }
             
-            if (-not ($scriptName -match '^((?<Name>[^:]+)(:(?<Version>[^:]+))?)$'))
+            if (-not ($requiredScript -match '^((?<Name>[^:]+)(:(?<Version>[^:]+))?)$'))
             {
-                $message = $LocalizedData.FailedToParseRequiredScripts -f ($scriptName)
-                ThrowError -ExceptionName "System.ArgumentException" `
-                            -ExceptionMessage $message `
-                            -ErrorId "FailedToParseRequiredScripts" `
-                            -CallerPSCmdlet $CallerPSCmdlet `
-                            -ErrorCategory InvalidOperation
+                $message = $LocalizedData.FailedToParseRequiredScripts -f ($requiredScript)
+
+                ThrowError `
+                    -ExceptionName "System.ArgumentException" `
+                    -ExceptionMessage $message `
+                    -ErrorId "FailedToParseRequiredScripts" `
+                    -CallerPSCmdlet $CallerPSCmdlet `
+                    -ErrorCategory InvalidOperation
             }
 
             $scriptName = $matches['Name']

--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -8411,7 +8411,14 @@ function Publish-PSArtifactUtility
             $VersionString = "$($Dependency.MinimumVersion)"
         }
 
-        $dependencies += "<dependency id='$($ModuleName)' version='$($VersionString)' />"
+        if ([System.string]::IsNullOrWhiteSpace($VersionString))
+        {
+            $dependencies += "<dependency id='$($ModuleName)'/>"
+        }
+        else 
+        {
+            $dependencies += "<dependency id='$($ModuleName)' version='$($VersionString)' />"
+        }
     }
     
     # Populate the nuspec elements

--- a/Tests/Asserts.psm1
+++ b/Tests/Asserts.psm1
@@ -184,6 +184,14 @@ function AssertNull
     Assert ($args[0] -eq $()) $args[1]
 }
 
+# Usage: AssertNullOrEmpty <object> <message>
+#
+function AssertNullOrEmpty
+{
+    Assert ($args.Length -eq 2) "AssertNullOrEmpty takes two parameters."
+    Assert ($args[0] -eq $() -or $args[0] -eq '') $args[1]
+}
+
 # This function waits for either a specified amount of time or for a script block to evaluate to true and throws an exception if the timeout period elapses.  Example:
 #
 #   WaitFor {get-process calc} 10000 250 "Calc.exe wasn't started within 10 seconds."


### PR DESCRIPTION
Added more functionality on 'REQIUREDSCRIPTS' when publishing modules/scripts
It allows user can specify a version of each 'REQIUREDSCRIPTS'. The legacy way that passing only script names are also available.
e.g.> Define 'REQUIREDSCRIPTS' without version (latest version)
.REQUIREDSCRIPTS DummyScript DummyScript2
e.g.>. Define 'REQUIREDSCRIPTS' with specific version
.REQUIREDSCRIPTS DummyScript;2.2.6 DummyScript2;1.0.1