### PR TITLE
Ensure MyDocumentsPSPath path is correct

### DIFF
--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -51,7 +51,8 @@ if($script:IsInbox)
 }
 elseif($script:IsWindows)
 {
-    $script:MyDocumentsPSPath = Microsoft.PowerShell.Management\Join-Path -Path $HOME -ChildPath 'Documents\PowerShell'
+    $script:MyDocumentsFolderPath = [Environment]::GetFolderPath("MyDocuments")
+    $script:MyDocumentsPSPath = Microsoft.PowerShell.Management\Join-Path -Path $script:MyDocumentsFolderPath -ChildPath 'PowerShell'
 }
 else
 {


### PR DESCRIPTION
Ensure that the user's My Documents PowerShell path for modules is
correct and not assumed to be under
C:\Users\[user]\Documents\PowerShell\