### PR TITLE
Fixed null parameter error caused by MinimumVersion in Publish-PackageUtility

### DIFF
--- a/PowerShellGet/PSModule.psm1
+++ b/PowerShellGet/PSModule.psm1
@@ -11357,17 +11357,26 @@ function Install-PackageUtility
                 {
                     if(-not $installUpdate)
                     {
-                        $result = ValidateAndGet-VersionPrereleaseStrings -Version $MinimumVersion -CallerPSCmdlet $PSCmdlet
-                        if (-not $result)
+                        if ($MinimumVersion)
                         {
-                            # ValidateAndGet-VersionPrereleaseStrings throws the error. 
-                            # returning to avoid further execution when different values are specified for -ErrorAction parameter
-                            return
+                            $result = ValidateAndGet-VersionPrereleaseStrings -Version $MinimumVersion -CallerPSCmdlet $PSCmdlet
+                            if (-not $result)
+                            {
+                                # ValidateAndGet-VersionPrereleaseStrings throws the error. 
+                                # returning to avoid further execution when different values are specified for -ErrorAction parameter
+                                return
+                            }
+                            $minVersion = $result["Version"]
+                            $minPrerelease = $result["Prerelease"]
+                            $minFullVersion = $result["FullVersion"]
                         }
-                        $minVersion = $result["Version"]
-                        $minPrerelease = $result["Prerelease"]
-                        $minFullVersion = $result["FullVersion"]
-
+                        else 
+                        {
+                            $minVersion = $null
+                            $minPrerelease = $null
+                            $minFullVersion = $null
+                        }
+                        
                         if( (-not $MinimumVersion -and ($galleryItemFullVersion -ne $InstalledModuleFullVersion)) -or 
                             ($MinimumVersion -and (Compare-PrereleaseVersions -FirstItemVersion $installedModuleVersion `
                                                                               -FirstItemPrerelease $installedModulePrerelease `
@@ -11435,16 +11444,26 @@ function Install-PackageUtility
 
                 if(-not $installUpdate)
                 {
-                    $result = ValidateAndGet-VersionPrereleaseStrings -Version $MinimumVersion -CallerPSCmdlet $PSCmdlet
-                    if (-not $result)
+                    if ($MinimumVersion)
                     {
-                        # ValidateAndGet-VersionPrereleaseStrings throws the error. 
-                        # returning to avoid further execution when different values are specified for -ErrorAction parameter
-                        return
+                        $result = ValidateAndGet-VersionPrereleaseStrings -Version $MinimumVersion -CallerPSCmdlet $PSCmdlet
+                        if (-not $result)
+                        {
+                            # ValidateAndGet-VersionPrereleaseStrings throws the error. 
+                            # returning to avoid further execution when different values are specified for -ErrorAction parameter
+                            return
+                        }
+                        $minVersion = $result["Version"]
+                        $minPrerelease = $result["Prerelease"]
+                        $minFullVersion = $result["FullVersion"]
                     }
-                    $minVersion = $result["Version"]
-                    $minPrerelease = $result["Prerelease"]
-                    $minFullVersion = $result["FullVersion"]
+                    else
+                    {
+                        $minVersion = $null
+                        $minPrerelease = $null
+                        $minFullVersion = $null
+                    }
+                    
 
                     if( (-not $MinimumVersion -and ($galleryItemFullVersion -ne $installedScriptFullVersion)) -or 
                         ($MinimumVersion -and (Compare-PrereleaseVersions -FirstItemVersion $installedScriptInfoVersion `


### PR DESCRIPTION
Error:
```powershell
PackageManagement\Install-Package : Cannot validate argument on parameter 'Version'. The argument is null or empty.
Provide an argument that is not null or empty, and then try the command again.
At C:\Program Files\WindowsPowerShell\Modules\PowerShellGet\1.5.0.0\PSModule.psm1:3930 char:21
+ ...          $null = PackageManagement\Install-Package @PSBoundParameters
+                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (Microsoft.Power....InstallPackage:InstallPackage) [Install-Package], Excep
   tion
    + FullyQualifiedErrorId : ParameterArgumentValidationError,ValidateAndGet-VersionPrereleaseStrings,Microsoft.Power
   Shell.PackageManagement.Cmdlets.InstallPackage
```

Caused by:
A null or empty value being passed to ValidateAndGet-VersionPrereleaseStrings -Version

Fix:
Adding null check before calling the function.