### PR TITLE
Install PSCore daily build using aka.ms/install-pscore in AppVeyor Test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,18 @@ Build status
 |-------------------------------------|------------------------------|
 | AppVeyor (Windows - PS 4.0)         | [![d-av-image][]][d-av-site] |
 | AppVeyor (Windows - PS 5.1)         | [![d-av-image][]][d-av-site] |
-| AppVeyor (Windows - PS 6.0.0-Alpha) | [![d-av-image][]][d-av-site] |
-| Travis CI (Linux - PS 6.0.0-Alpha)  | [![d-tv-image][]][d-tv-site] |
-| Travis CI (MacOS - PS 6.0.0-Alpha)  | [![d-tv-image][]][d-tv-site] |
+| AppVeyor (Windows - PS 6.0.0+)      | [![d-av-image][]][d-av-site] |
+| Travis CI (Linux - PS 6.0.0+)       | [![d-tv-image][]][d-tv-site] |
+| Travis CI (MacOS - PS 6.0.0+)       | [![d-tv-image][]][d-tv-site] |
 
 ## Master branch
 |         OS - PS Version             |          Build Status        |
 |-------------------------------------|------------------------------|
 | AppVeyor (Windows - PS 4.0)         | [![m-av-image][]][m-av-site] |
 | AppVeyor (Windows - PS 5.1)         | [![m-av-image][]][m-av-site] |
-| AppVeyor (Windows - PS 6.0.0-Alpha) | [![m-av-image][]][m-av-site] |
-| Travis CI (Linux - PS 6.0.0-Alpha)  | [![m-tv-image][]][m-tv-site] |
-| Travis CI (MacOS - PS 6.0.0-Alpha)  | [![m-tv-image][]][m-tv-site] |
+| AppVeyor (Windows - PS 6.0.0+)      | [![m-av-image][]][m-av-site] |
+| Travis CI (Linux - PS 6.0.0+)       | [![m-tv-image][]][m-tv-site] |
+| Travis CI (MacOS - PS 6.0.0+)       | [![m-tv-image][]][m-tv-site] |
 
 [d-av-image]: https://ci.appveyor.com/api/projects/status/91p7lpjoxit3gw72/branch/development?svg=true
 [d-av-site]: https://ci.appveyor.com/project/PowerShell/powershellget/branch/development
@@ -55,9 +55,9 @@ Daily Build status
 |-------------------------------------|------------------------------|
 | AppVeyor (Windows - PS 4.0)         | [![d-n-av-image][]][d-n-av-site] |
 | AppVeyor (Windows - PS 5.1)         | [![d-n-av-image][]][d-n-av-site] |
-| AppVeyor (Windows - PS 6.0.0-Alpha) | [![d-n-av-image][]][d-n-av-site] |
-| Travis CI (Linux - PS 6.0.0-Alpha)  | [![d-tv-image][]][d-tv-site] |
-| Travis CI (MacOS - PS 6.0.0-Alpha)  | [![d-tv-image][]][d-tv-site] |
+| AppVeyor (Windows - PS 6.0.0+)      | [![d-n-av-image][]][d-n-av-site] |
+| Travis CI (Linux - PS 6.0.0+)       | [![d-tv-image][]][d-tv-site] |
+| Travis CI (MacOS - PS 6.0.0+)       | [![d-tv-image][]][d-tv-site] |
 
 [d-n-av-image]: https://ci.appveyor.com/api/projects/status/58muo6i0x8n38pd3/branch/development?svg=true
 [d-n-av-site]: https://ci.appveyor.com/project/PowerShell/powershellget-0lib3/branch/development

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
     PowerShellEdition: Desktop
   - APPVEYOR_BUILD_WORKER_IMAGE: WMF 4
     PowerShellEdition: Desktop
-  - APPVEYOR_BUILD_WORKER_IMAGE: WMF 4
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     PowerShellEdition: Core
 
 configuration: Release


### PR DESCRIPTION
- Added required changes to install the PSCore daily builds using https://aka.ms/install-pscore script.
  - https://aka.ms/install-pscore --> https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/install-powershell.ps1
- Updated AppVeyor image to VS 2017 as https://aka.ms/install-pscore requires PackageManagement module for installing the daily PSCore builds.
- Made minor updates in readme.md for PS Core versions under build status.
- Minor change for removing the PSGetModuleInfo.xml under DockerMsftProvider module.
  - Latest AppVeyor VMs are installed with DockerMsftProvider module using PowerShellGet cmdlet.
  - A test for Update-Module (without any parameter values) is prompting for updating DockerMsftProvider to the latest version as the PSGallery repository's default installation policy is untrusted.