### PR TITLE
Fix for Get-InstalledScript -RequiredVersion doesn't work when versions have a leading 0

### DIFF
--- a/PowerShellGet/PSGet.Resource.psd1
+++ b/PowerShellGet/PSGet.Resource.psd1
@@ -30,7 +30,7 @@ ConvertFrom-StringData @'
         ModuleAlreadyInstalled=Version '{0}' of module '{1}' is already installed at '{2}'. To delete version '{3}' and install version '{4}', run Install-Module, and add the -Force parameter.
         ScriptAlreadyInstalled=Version '{0}' of script '{1}' is already installed at '{2}'. To delete version '{3}' and install version '{4}', run Install-Script, and add the -Force parameter.
         CommandAlreadyAvailable=A command with name '{0}' is already available on this system. This script '{0}' may override the existing command. If you still want to install this script '{0}', use -Force parameter.
-        ModuleAlreadyInstalledSxS=Version '{0}' of module '{1}' is already installed at '{2}'. To install version '{3}', run Install-Module and add the -Force parameter, this command will install version '{5}' in side-by-side with version '{4}'.
+        ModuleAlreadyInstalledSxS=Version '{0}' of module '{1}' is already installed at '{2}'. To install version '{3}', run Install-Module and add the -Force parameter, this command will install version '{5}' side-by-side with version '{4}'.
         ModuleAlreadyInstalledVerbose=Version '{0}' of module '{1}' is already installed at '{2}'.
         ScriptAlreadyInstalledVerbose=Version '{0}' of script '{1}' is already installed at '{2}'.
         ModuleWithRequiredVersionAlreadyInstalled=Version '{0}' of module '{1}' is already installed at '{2}'. To reinstall this version '{3}', run Install-Module or Updated-Module cmdlet with the -Force parameter.

--- a/PowerShellGet/private/functions/ValidateAndGet-VersionPrereleaseStrings.ps1
+++ b/PowerShellGet/private/functions/ValidateAndGet-VersionPrereleaseStrings.ps1
@@ -72,10 +72,10 @@ function ValidateAndGet-VersionPrereleaseStrings
                    -ExceptionObject $Version
     }
 
-    $fullVersion = if ($Prerelease) { "$Version-$Prerelease" } else { $Version }
+    $fullVersion = if ($Prerelease) { "$VersionVersion-$Prerelease" } else { "$VersionVersion" }
 
     $results = @{
-        Version = $Version
+        Version = "$VersionVersion"
         Prerelease = $Prerelease
         FullVersion = $fullVersion
     }

--- a/README.md
+++ b/README.md
@@ -117,9 +117,18 @@ Run following commands in PowerShell Console with Administrator privileges.
 Import-Module "$ClonePath\tools\build.psm1"
 
 Install-Dependencies
-# Execute the following, replacing $ClonePath, when testing PSGet changes
+
+# Option 1: Execute the following, replacing $ClonePath, when testing PowerShellGet module changes under $ClonePath.
 # $env:PSModulePath = "$ClonePath;$env:PSModulePath"
 
+# Option 2: Execute the following commands to run tests with the merged PSModule.psm1
+<#
+Update-ModuleManifestFunctions
+Publish-ModuleArtifacts
+Install-PublishedModule
+#>
+
+# Run tests
 Invoke-PowerShellGetTest
 ```
 

--- a/Tests/PSGetInstallScript.Tests.ps1
+++ b/Tests/PSGetInstallScript.Tests.ps1
@@ -1754,4 +1754,16 @@ Describe PowerShell.PSGet.InstallScriptTests.P1 -Tags 'P1','OuterLoop' {
         }
     } `
     -Skip:$($PSCulture -ne 'en-US')
+
+    It "Get-InstalledScript cmdlet with leading zeros in RequiredVersion value" {
+        $scriptName = 'Fabrikam-ServerScript'
+        $version = '1.2'
+        Install-Script $scriptName -RequiredVersion $version
+        $res = Get-InstalledScript $scriptName -RequiredVersion '1.02'
+        $res.Name | Should Be $scriptName
+        $res.Version | Should Be $version
+
+        $res = Get-InstalledScript $scriptName -RequiredVersion $version
+        $res.Version | Should Be $version
+    }
 }


### PR DESCRIPTION
Additional changes:
- Updated Readme.md to include additional steps for running tests with the merged psmodule.psm1 file.
- Fixed a typo in the verbose message.