### PR TITLE
Specify AllowPrereleaseVersions provider option only when AllowPrerelease is specified on the PowerShellGet cmdlets

### DIFF
--- a/PowerShellGet/public/psgetfunctions/Find-Module.ps1
+++ b/PowerShellGet/public/psgetfunctions/Find-Module.ps1
@@ -116,7 +116,9 @@ function Find-Module
 
         $PSBoundParameters["Provider"] = $script:PSModuleProviderName
         $PSBoundParameters[$script:PSArtifactType] = $script:PSArtifactTypeModule
-        $PSBoundParameters[$script:AllowPrereleaseVersions] = $AllowPrerelease
+        if($AllowPrerelease) {
+            $PSBoundParameters[$script:AllowPrereleaseVersions] = $true
+        }
         $null = $PSBoundParameters.Remove("AllowPrerelease")
 
         if($PSBoundParameters.ContainsKey("Repository"))

--- a/PowerShellGet/public/psgetfunctions/Find-Script.ps1
+++ b/PowerShellGet/public/psgetfunctions/Find-Script.ps1
@@ -106,7 +106,9 @@ function Find-Script
 
         $PSBoundParameters['Provider'] = $script:PSModuleProviderName
         $PSBoundParameters[$script:PSArtifactType] = $script:PSArtifactTypeScript
-        $PSBoundParameters[$script:AllowPrereleaseVersions] = $AllowPrerelease
+        if($AllowPrerelease) {
+            $PSBoundParameters[$script:AllowPrereleaseVersions] = $true
+        }
         $null = $PSBoundParameters.Remove("AllowPrerelease")
 
         if($PSBoundParameters.ContainsKey("Repository"))

--- a/PowerShellGet/public/psgetfunctions/Get-InstalledModule.ps1
+++ b/PowerShellGet/public/psgetfunctions/Get-InstalledModule.ps1
@@ -56,7 +56,9 @@ function Get-InstalledModule
         $PSBoundParameters["Provider"] = $script:PSModuleProviderName
         $PSBoundParameters["MessageResolver"] = $script:PackageManagementMessageResolverScriptBlock
         $PSBoundParameters[$script:PSArtifactType] = $script:PSArtifactTypeModule
-        $PSBoundParameters[$script:AllowPrereleaseVersions] = $AllowPrerelease
+        if($AllowPrerelease) {
+            $PSBoundParameters[$script:AllowPrereleaseVersions] = $true
+        }
         $null = $PSBoundParameters.Remove("AllowPrerelease")
 
         PackageManagement\Get-Package @PSBoundParameters | Microsoft.PowerShell.Core\ForEach-Object {New-PSGetItemInfo -SoftwareIdentity $_ -Type $script:PSArtifactTypeModule}

--- a/PowerShellGet/public/psgetfunctions/Get-InstalledScript.ps1
+++ b/PowerShellGet/public/psgetfunctions/Get-InstalledScript.ps1
@@ -51,7 +51,9 @@ function Get-InstalledScript
         $PSBoundParameters["Provider"] = $script:PSModuleProviderName
         $PSBoundParameters["MessageResolver"] = $script:PackageManagementMessageResolverScriptBlockForScriptCmdlets
         $PSBoundParameters[$script:PSArtifactType] = $script:PSArtifactTypeScript
-        $PSBoundParameters[$script:AllowPrereleaseVersions] = $AllowPrerelease
+        if($AllowPrerelease) {
+            $PSBoundParameters[$script:AllowPrereleaseVersions] = $true
+        }
         $null = $PSBoundParameters.Remove("AllowPrerelease")
 
         PackageManagement\Get-Package @PSBoundParameters | Microsoft.PowerShell.Core\ForEach-Object {New-PSGetItemInfo -SoftwareIdentity $_ -Type $script:PSArtifactTypeScript}

--- a/PowerShellGet/public/psgetfunctions/Install-Module.ps1
+++ b/PowerShellGet/public/psgetfunctions/Install-Module.ps1
@@ -123,7 +123,9 @@ function Install-Module
         $PSBoundParameters["MessageResolver"] = $script:PackageManagementInstallModuleMessageResolverScriptBlock
         $PSBoundParameters[$script:PSArtifactType] = $script:PSArtifactTypeModule
         $PSBoundParameters['Scope'] = $Scope
-        $PSBoundParameters[$script:AllowPrereleaseVersions] = $AllowPrerelease
+        if($AllowPrerelease) {
+            $PSBoundParameters[$script:AllowPrereleaseVersions] = $true
+        }
         $null = $PSBoundParameters.Remove("AllowPrerelease")
 
         if($PSCmdlet.ParameterSetName -eq "NameParameterSet")
@@ -210,7 +212,6 @@ function Install-Module
 
                 $PSBoundParameters["Name"] = $psgetModuleInfo.Name
                 $PSBoundParameters["RequiredVersion"] = $psgetModuleInfo.Version
-                $PSBoundParameters[$script:AllowPrereleaseVersions] = $psgetModuleInfo.AdditionalMetadata.IsPrerelease -eq "true"
                 $PSBoundParameters['Source'] = $psgetModuleInfo.Repository
                 $PSBoundParameters["PackageManagementProvider"] = (Get-ProviderName -PSCustomObject $psgetModuleInfo)
 

--- a/PowerShellGet/public/psgetfunctions/Install-Module.ps1
+++ b/PowerShellGet/public/psgetfunctions/Install-Module.ps1
@@ -212,6 +212,14 @@ function Install-Module
 
                 $PSBoundParameters["Name"] = $psgetModuleInfo.Name
                 $PSBoundParameters["RequiredVersion"] = $psgetModuleInfo.Version
+                if (($psgetModuleInfo.AdditionalMetadata) -and
+                    (Get-Member -InputObject $psgetModuleInfo.AdditionalMetadata -Name "IsPrerelease") -and
+                    ($psgetModuleInfo.AdditionalMetadata.IsPrerelease -eq "true")) {
+                    $PSBoundParameters[$script:AllowPrereleaseVersions] = $true
+                }
+                elseif ($PSBoundParameters.ContainsKey($script:AllowPrereleaseVersions)) {
+                    $null = $PSBoundParameters.Remove($script:AllowPrereleaseVersions)
+                }
                 $PSBoundParameters['Source'] = $psgetModuleInfo.Repository
                 $PSBoundParameters["PackageManagementProvider"] = (Get-ProviderName -PSCustomObject $psgetModuleInfo)
 

--- a/PowerShellGet/public/psgetfunctions/Install-Script.ps1
+++ b/PowerShellGet/public/psgetfunctions/Install-Script.ps1
@@ -258,6 +258,14 @@ function Install-Script
 
                 $PSBoundParameters["Name"] = $psRepositoryItemInfo.Name
                 $PSBoundParameters["RequiredVersion"] = $psRepositoryItemInfo.Version
+                if (($psRepositoryItemInfo.AdditionalMetadata) -and
+                    (Get-Member -InputObject $psRepositoryItemInfo.AdditionalMetadata -Name "IsPrerelease") -and
+                    ($psRepositoryItemInfo.AdditionalMetadata.IsPrerelease -eq "true")) {
+                    $PSBoundParameters[$script:AllowPrereleaseVersions] = $true
+                }
+                elseif ($PSBoundParameters.ContainsKey($script:AllowPrereleaseVersions)) {
+                    $null = $PSBoundParameters.Remove($script:AllowPrereleaseVersions)
+                }
                 $PSBoundParameters['Source'] = $psRepositoryItemInfo.Repository
                 $PSBoundParameters["PackageManagementProvider"] = (Get-ProviderName -PSCustomObject $psRepositoryItemInfo)
 

--- a/PowerShellGet/public/psgetfunctions/Install-Script.ps1
+++ b/PowerShellGet/public/psgetfunctions/Install-Script.ps1
@@ -136,7 +136,9 @@ function Install-Script
         $PSBoundParameters["MessageResolver"] = $script:PackageManagementInstallScriptMessageResolverScriptBlock
         $PSBoundParameters[$script:PSArtifactType] = $script:PSArtifactTypeScript
         $PSBoundParameters['Scope'] = $Scope
-        $PSBoundParameters[$script:AllowPrereleaseVersions] = $AllowPrerelease
+        if($AllowPrerelease) {
+            $PSBoundParameters[$script:AllowPrereleaseVersions] = $true
+        }
         $null = $PSBoundParameters.Remove("AllowPrerelease")
 
         if($PSCmdlet.ParameterSetName -eq "NameParameterSet")

--- a/PowerShellGet/public/psgetfunctions/Save-Module.ps1
+++ b/PowerShellGet/public/psgetfunctions/Save-Module.ps1
@@ -118,7 +118,9 @@ function Save-Module
         $PSBoundParameters["Provider"] = $script:PSModuleProviderName
         $PSBoundParameters["MessageResolver"] = $script:PackageManagementSaveModuleMessageResolverScriptBlock
         $PSBoundParameters[$script:PSArtifactType] = $script:PSArtifactTypeModule
-        $PSBoundParameters[$script:AllowPrereleaseVersions] = $AllowPrerelease
+        if($AllowPrerelease) {
+            $PSBoundParameters[$script:AllowPrereleaseVersions] = $true
+        }
         $null = $PSBoundParameters.Remove("AllowPrerelease")
 
         # When -Force is specified, Path will be created if not available.

--- a/PowerShellGet/public/psgetfunctions/Save-Module.ps1
+++ b/PowerShellGet/public/psgetfunctions/Save-Module.ps1
@@ -247,6 +247,14 @@ function Save-Module
 
                 $PSBoundParameters["Name"] = $psgetModuleInfo.Name
                 $PSBoundParameters["RequiredVersion"] = $psgetModuleInfo.Version
+                if (($psgetModuleInfo.AdditionalMetadata) -and
+                    (Get-Member -InputObject $psgetModuleInfo.AdditionalMetadata -Name "IsPrerelease") -and
+                    ($psgetModuleInfo.AdditionalMetadata.IsPrerelease -eq "true")) {
+                    $PSBoundParameters[$script:AllowPrereleaseVersions] = $true
+                }
+                elseif ($PSBoundParameters.ContainsKey($script:AllowPrereleaseVersions)) {
+                    $null = $PSBoundParameters.Remove($script:AllowPrereleaseVersions)
+                }
                 $PSBoundParameters['Source'] = $psgetModuleInfo.Repository
                 $PSBoundParameters["PackageManagementProvider"] = (Get-ProviderName -PSCustomObject $psgetModuleInfo)
 

--- a/PowerShellGet/public/psgetfunctions/Save-Script.ps1
+++ b/PowerShellGet/public/psgetfunctions/Save-Script.ps1
@@ -130,7 +130,9 @@ function Save-Script
         $PSBoundParameters["Provider"] = $script:PSModuleProviderName
         $PSBoundParameters["MessageResolver"] = $script:PackageManagementSaveScriptMessageResolverScriptBlock
         $PSBoundParameters[$script:PSArtifactType] = $script:PSArtifactTypeScript
-        $PSBoundParameters[$script:AllowPrereleaseVersions] = $AllowPrerelease
+        if($AllowPrerelease) {
+            $PSBoundParameters[$script:AllowPrereleaseVersions] = $true
+        }
         $null = $PSBoundParameters.Remove("AllowPrerelease")
 
         # When -Force is specified, Path will be created if not available.

--- a/PowerShellGet/public/psgetfunctions/Save-Script.ps1
+++ b/PowerShellGet/public/psgetfunctions/Save-Script.ps1
@@ -263,6 +263,14 @@ function Save-Script
 
                 $PSBoundParameters["Name"] = $psRepositoryItemInfo.Name
                 $PSBoundParameters["RequiredVersion"] = $psRepositoryItemInfo.Version
+                if (($psRepositoryItemInfo.AdditionalMetadata) -and
+                    (Get-Member -InputObject $psRepositoryItemInfo.AdditionalMetadata -Name "IsPrerelease") -and
+                    ($psRepositoryItemInfo.AdditionalMetadata.IsPrerelease -eq "true")) {
+                    $PSBoundParameters[$script:AllowPrereleaseVersions] = $true
+                }
+                elseif ($PSBoundParameters.ContainsKey($script:AllowPrereleaseVersions)) {
+                    $null = $PSBoundParameters.Remove($script:AllowPrereleaseVersions)
+                }
                 $PSBoundParameters['Source'] = $psRepositoryItemInfo.Repository
                 $PSBoundParameters["PackageManagementProvider"] = (Get-ProviderName -PSCustomObject $psRepositoryItemInfo)
 

--- a/PowerShellGet/public/psgetfunctions/Uninstall-Module.ps1
+++ b/PowerShellGet/public/psgetfunctions/Uninstall-Module.ps1
@@ -81,6 +81,14 @@ function Uninstall-Module
 
                 $PSBoundParameters["Name"] = $inputValue.Name
                 $PSBoundParameters["RequiredVersion"] = $inputValue.Version
+                if (($inputValue.AdditionalMetadata) -and
+                    (Get-Member -InputObject $inputValue.AdditionalMetadata -Name "IsPrerelease") -and
+                    ($inputValue.AdditionalMetadata.IsPrerelease -eq "true")) {
+                    $PSBoundParameters[$script:AllowPrereleaseVersions] = $true
+                }
+                elseif ($PSBoundParameters.ContainsKey($script:AllowPrereleaseVersions)) {
+                    $null = $PSBoundParameters.Remove($script:AllowPrereleaseVersions)
+                }
 
                 $null = PackageManagement\Uninstall-Package @PSBoundParameters
             }

--- a/PowerShellGet/public/psgetfunctions/Uninstall-Script.ps1
+++ b/PowerShellGet/public/psgetfunctions/Uninstall-Script.ps1
@@ -57,7 +57,9 @@ function Uninstall-Script
         $PSBoundParameters["Provider"] = $script:PSModuleProviderName
         $PSBoundParameters["MessageResolver"] = $script:PackageManagementUnInstallScriptMessageResolverScriptBlock
         $PSBoundParameters[$script:PSArtifactType] = $script:PSArtifactTypeScript
-        $PSBoundParameters[$script:AllowPrereleaseVersions] = $AllowPrerelease
+        if($AllowPrerelease) {
+            $PSBoundParameters[$script:AllowPrereleaseVersions] = $true
+        }
         $null = $PSBoundParameters.Remove("AllowPrerelease")
 
         if($PSCmdlet.ParameterSetName -eq "InputObject")

--- a/PowerShellGet/public/psgetfunctions/Uninstall-Script.ps1
+++ b/PowerShellGet/public/psgetfunctions/Uninstall-Script.ps1
@@ -81,6 +81,14 @@ function Uninstall-Script
 
                 $PSBoundParameters["Name"] = $inputValue.Name
                 $PSBoundParameters["RequiredVersion"] = $inputValue.Version
+                if (($inputValue.AdditionalMetadata) -and
+                    (Get-Member -InputObject $inputValue.AdditionalMetadata -Name "IsPrerelease") -and
+                    ($inputValue.AdditionalMetadata.IsPrerelease -eq "true")) {
+                    $PSBoundParameters[$script:AllowPrereleaseVersions] = $true
+                }
+                elseif ($PSBoundParameters.ContainsKey($script:AllowPrereleaseVersions)) {
+                    $null = $PSBoundParameters.Remove($script:AllowPrereleaseVersions)
+                }
 
                 $null = PackageManagement\Uninstall-Package @PSBoundParameters
             }

--- a/PowerShellGet/public/psgetfunctions/Update-Module.ps1
+++ b/PowerShellGet/public/psgetfunctions/Update-Module.ps1
@@ -78,7 +78,9 @@ function Update-Module
         $GetPackageParameters["MessageResolver"] = $script:PackageManagementMessageResolverScriptBlock
         $GetPackageParameters['ErrorAction'] = 'SilentlyContinue'
         $GetPackageParameters['WarningAction'] = 'SilentlyContinue'
-        $PSBoundParameters[$script:AllowPrereleaseVersions] = $AllowPrerelease
+        if($AllowPrerelease) {
+            $PSBoundParameters[$script:AllowPrereleaseVersions] = $true
+        }
         $null = $PSBoundParameters.Remove("AllowPrerelease")
 
         $PSGetItemInfos = @()

--- a/PowerShellGet/public/psgetfunctions/Update-Script.ps1
+++ b/PowerShellGet/public/psgetfunctions/Update-Script.ps1
@@ -200,7 +200,9 @@ function Update-Script
             $PSBoundParameters["PackageManagementProvider"] = $providerName
             $PSBoundParameters["Name"] = $psgetItemInfo.Name
             $PSBoundParameters['Source'] = $psgetItemInfo.Repository
-            $PSBoundParameters[$script:AllowPrereleaseVersions] = $AllowPrerelease
+            if($AllowPrerelease) {
+                $PSBoundParameters[$script:AllowPrereleaseVersions] = $true
+            }
             $null = $PSBoundParameters.Remove("AllowPrerelease")
 
             Get-PSGalleryApiAvailability -Repository (Get-SourceName -Location $psgetItemInfo.RepositorySourceLocation)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,11 @@ init:
 # Install Pester and PackageManagement modules
 install:
     - ps: |
+        # Some AppVeyor OS images (ex: VS 2017) are pre-installed with the Azure modules using PowerShellGet cmdlets.
+        # These pre-installed modules are causing prompts during Update-Module tests as the PSGallery repository is untrusted by design.
+        # Below command removes the PSGetModuleInfo.xml files created by the Install-Module cmdlet.
+        Get-Module -ListAvailable | ForEach-Object {Join-Path -Path $_.ModuleBase -ChildPath 'PSGetModuleInfo.xml'} | Where-Object {Test-Path -Path $_ -PathType Leaf} | Remove-Item -Force
+
         Import-Module .\tools\build.psm1
         Install-Dependencies
         Update-ModuleManifestFunctions


### PR DESCRIPTION
- Some users are not re-launching the PowerShell console after installing an updated version of PowerShellGet module,  using the same PS console will result in "AllowPrereleaseVersions parameter cannot be found" error.

- Also updated the appveyor.yml to remove PSGetModuleInfo.xml from the pre-installed Azure modules on AppVeyor VMs.