### PR TITLE
better error handling in network connectivity tests

### DIFF
--- a/PowerShellGet/private/functions/Check-PSGalleryApiAvailability.ps1
+++ b/PowerShellGet/private/functions/Check-PSGalleryApiAvailability.ps1
@@ -46,7 +46,7 @@ function Check-PSGalleryApiAvailability
         } 
         catch 
         {
-            # there is no -ErrorAction switch on method call, we must use empty catch block to suppress error
+            # there is no -ErrorAction on method call, we must use empty catch block to suppress error
         } 
     }
 

--- a/PowerShellGet/private/functions/Check-PSGalleryApiAvailability.ps1
+++ b/PowerShellGet/private/functions/Check-PSGalleryApiAvailability.ps1
@@ -18,21 +18,36 @@ function Check-PSGalleryApiAvailability
     $microsoftDomain = 'www.microsoft.com'
     if((-not $script:IsCoreCLR) -and (Get-Command Microsoft.PowerShell.Management\Test-Connection -ErrorAction Ignore))
     {
-        try {
+        try
+        {
             $connected = Microsoft.PowerShell.Management\Test-Connection -ComputerName $microsoftDomain -Count 1 -Quiet
-        } catch {} # Test-Connection throws an exception even with -EA SilentlyIgnore
+        } 
+        catch 
+        {
+            # Test-Connection throws an exception even with -EA SilentlyIgnore, we must use try catch to suppress it
+        } 
     }
     if(( -not $connected) -and (Get-Command NetTCPIP\Test-Connection -ErrorAction Ignore))
     {
-        try {
+        try 
+        {
             $connected = NetTCPIP\Test-NetConnection -ComputerName $microsoftDomain -InformationLevel Quiet
-        } catch {} # $connected is already set to $false on all three empty catch blocks
+        } 
+        catch 
+        {
+            # $connected is already set to $false, this applies on all three empty catch blocks   
+        } 
     }
     if ( -not $connected) 
     {
-        try {
+        try 
+        {
             $connected = [System.Net.NetworkInformation.NetworkInterface]::GetIsNetworkAvailable()
-        } catch {} # no -EA on method call
+        } 
+        catch 
+        {
+            # there is no -ErrorAction switch on method call, we must use empty catch block to suppress error
+        } 
     }
 
     if ( -not $connected)

--- a/PowerShellGet/private/functions/Check-PSGalleryApiAvailability.ps1
+++ b/PowerShellGet/private/functions/Check-PSGalleryApiAvailability.ps1
@@ -18,15 +18,21 @@ function Check-PSGalleryApiAvailability
     $microsoftDomain = 'www.microsoft.com'
     if((-not $script:IsCoreCLR) -and (Get-Command Microsoft.PowerShell.Management\Test-Connection -ErrorAction Ignore))
     {
-        $connected = Microsoft.PowerShell.Management\Test-Connection -ComputerName $microsoftDomain -Count 1 -Quiet
+        try {
+            $connected = Microsoft.PowerShell.Management\Test-Connection -ComputerName $microsoftDomain -Count 1 -Quiet
+        } catch {} # Test-Connection throws an exception even with -EA SilentlyIgnore
     }
-    elseif(Get-Command NetTCPIP\Test-Connection -ErrorAction Ignore)
+    if(( -not $connected) -and (Get-Command NetTCPIP\Test-Connection -ErrorAction Ignore))
     {
-        $connected = NetTCPIP\Test-NetConnection -ComputerName $microsoftDomain -InformationLevel Quiet
+        try {
+            $connected = NetTCPIP\Test-NetConnection -ComputerName $microsoftDomain -InformationLevel Quiet
+        } catch {} # $connected is already set to $false on all three empty catch blocks
     }
-    else
+    if ( -not $connected) 
     {
-        $connected = [System.Net.NetworkInformation.NetworkInterface]::GetIsNetworkAvailable()
+        try {
+            $connected = [System.Net.NetworkInformation.NetworkInterface]::GetIsNetworkAvailable()
+        } catch {} # no -EA on method call
     }
 
     if ( -not $connected)


### PR DESCRIPTION
As per #270, if any of three tests return $true, network is available. Currently, any failing test will prevent next ones (potentially successful) from running.