### PR TITLE
Fix to prevent Update-ModuleManifest from reverting LicenseUri (#294)

### DIFF
--- a/PowerShellGet/public/psgetfunctions/Update-ModuleManifest.ps1
+++ b/PowerShellGet/public/psgetfunctions/Update-ModuleManifest.ps1
@@ -699,7 +699,7 @@ function Update-ModuleManifest
 
         #Manually update the section in PrivateData since New-ModuleManifest works differently on different PS version
         $PrivateDataInput = ""
-        $ExistingData = $moduleInfo.PrivateData
+        $ExistingData = $ModuleManifestHashTable.PrivateData
         $Data = @{}
         if($ExistingData)
         {

--- a/Tests/PSGetUpdateModuleManifest.Tests.ps1
+++ b/Tests/PSGetUpdateModuleManifest.Tests.ps1
@@ -519,6 +519,36 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
     } 
 
 
+    # Purpose: To ensure key values from previous calls are not reverted to their original value.
+    #
+    # Action:
+    #      Update-ModuleManifest -Path [Path] -RootModule [Path]
+    #      Update-ModuleManifest -Path [Path] -LicenseUri [Uri]
+    #      Update-ModuleManifest -Path [Path] -HelpUri [Uri]
+    #
+    # Expected Result: After all to Update-ModouleManifest, the values that were passed in for RootModule, LicenseUri and HelpInfoUri parameters should be the same values during assertation.
+    #
+    It UpdateModuleManifestWithConsecutiveCallsForNestedManifestKeys {
+
+        Set-Content "$script:UpdateModuleManifestBase\$script:UpdateModuleManifestName.psm1" -Value "function Get-$script:UpdateModuleManifestName { Get-Date }"
+
+        $LicenseUri = "https://$script:UpdateModuleManifestName.com/1.0.0/license"
+        $HelpInfoURI = "https://$script:UpdateModuleManifestName.com/HelpInfoURI"
+
+        New-ModuleManifest -path $script:testManifestPath
+
+        Update-ModuleManifest -path $script:testManifestPath -RootModule "$script:UpdateModuleManifestName.psm1"
+        Update-ModuleManifest -path $script:testManifestPath -LicenseUri $LicenseUri
+        Update-ModuleManifest -path $script:testManifestPath -HelpInfoUri $HelpInfoURI
+
+        $newModuleInfo = Test-ModuleManifest -Path $script:testManifestPath
+
+        AssertEquals $newModuleInfo.RootModule "$script:UpdateModuleManifestName.psm1" "RootModule should be $($script:UpdateModuleManifestName.psm1)"
+        AssertEqualsCaseInsensitive $newModuleInfo.LicenseUri $LicenseUri "LicenseUri should be $($LicenseUri)"
+        AssertEqualsCaseInsensitive $newModuleInfo.HelpInfoURI $HelpInfoURI "HelpInfoURI should be $($HelpInfoURI)"
+    }
+
+
 
     # Purpose: Validate Update-ModuleManifest cmdlet throw warnings when ExportedDSCResources is specified for PowerShell version lower than 5.0
     #


### PR DESCRIPTION
Here is my most conservative solution to #294.  

@JustinGrote comment would require another pull-request. He did mention about an alternative function for Update-ModuleManifest which may be beneficial for updates within PowerShellGet. I noticed for the issue he is having involves PowerShellGet's Get-PrivateData which perhaps can benefit from HashData's [ConvertTo-HashString](https://github.com/torgro/HashData/blob/master/Functions/ConvertTo-HashString.ps1) with a few changes.