### PR TITLE
Fix CommandAlreadyAvailable error for PackageManagement module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 ## 2.0.1
-Bug fix
+Bug fixes
 - Resolved Publish-Module doesn't report error but fails to publish module (#316)
+- Resolved CommandAlreadyAvailable error while installing the latest version of PackageManagement module (#333)
 
 ## 2.0.0
 Breaking Change

--- a/PowerShellGet/PowerShellGet.psd1
+++ b/PowerShellGet/PowerShellGet.psd1
@@ -55,8 +55,9 @@ PrivateData = @{
         LicenseUri = 'https://go.microsoft.com/fwlink/?LinkId=829061'
         ReleaseNotes = @'
 ## 2.0.1
-Bug fix
+Bug fixes
 - Resolved Publish-Module doesn't report error but fails to publish module (#316)
+- Resolved CommandAlreadyAvailable error while installing the latest version of PackageManagement module (#333)
 
 ## 2.0.0
 

--- a/PowerShellGet/private/functions/Validate-ModuleCommandAlreadyAvailable.ps1
+++ b/PowerShellGet/private/functions/Validate-ModuleCommandAlreadyAvailable.ps1
@@ -56,6 +56,7 @@ function Validate-ModuleCommandAlreadyAvailable
                                                                       -WarningAction SilentlyContinue |
                                     Microsoft.PowerShell.Core\Where-Object { ($CommandNames -contains $_.Name) -and
                                                                              ($_.ModuleName -ne $script:PSModuleProviderName) -and
+                                                                             ($_.ModuleName -ne 'PSModule') -and
                                                                              ($_.ModuleName -ne $CurrentModuleInfo.Name) }
             if($AvailableCommands)
             {


### PR DESCRIPTION
This is happening as Get-Command returns the local commands from PSModule.psm1 for the Find-Package, Install-Package and Uninstall-Package provider functions. Added check to ignore the commands from PSModule.psm1.

Resolves #329