### PR TITLE
Remove trailing whitespace

### DIFF
--- a/PowerShellGet/private/functions/Get-PSScriptInfoString.ps1
+++ b/PowerShellGet/private/functions/Get-PSScriptInfoString.ps1
@@ -69,34 +69,34 @@ function Get-PSScriptInfoString
 
 <#PSScriptInfo
 
-.VERSION $Version
+.VERSION$(if ($Version) {" $Version"})
 
-.GUID $Guid
+.GUID$(if ($Guid) {" $Guid"})
 
-.AUTHOR $Author
+.AUTHOR$(if ($Author) {" $Author"})
 
-.COMPANYNAME $CompanyName
+.COMPANYNAME$(if ($CompanyName) {" $CompanyName"})
 
-.COPYRIGHT $Copyright
+.COPYRIGHT$(if ($Copyright) {" $Copyright"})
 
-.TAGS $Tags
+.TAGS$(if ($Tags) {" $Tags"})
 
-.LICENSEURI $LicenseUri
+.LICENSEURI$(if ($LicenseUri) {" $LicenseUri"})
 
-.PROJECTURI $ProjectUri
+.PROJECTURI$(if ($ProjectUri) {" $ProjectUri"})
 
-.ICONURI $IconUri
+.ICONURI$(if ($IconUri) {" $IconUri"})
 
-.EXTERNALMODULEDEPENDENCIES $($ExternalModuleDependencies -join ',')
+.EXTERNALMODULEDEPENDENCIES$(if ($ExternalModuleDependencies) {" $($ExternalModuleDependencies -join ',')"}) 
 
-.REQUIREDSCRIPTS $($RequiredScripts -join ',')
+.REQUIREDSCRIPTS$(if ($RequiredScripts) {" $($RequiredScripts -join ',')"})
 
-.EXTERNALSCRIPTDEPENDENCIES $($ExternalScriptDependencies -join ',')
+.EXTERNALSCRIPTDEPENDENCIES$(if ($ExternalScriptDependencies) {" $($ExternalScriptDependencies -join ',')"})
 
 .RELEASENOTES
 $($ReleaseNotes -join "`r`n")
 
-.PRIVATEDATA $PrivateData
+.PRIVATEDATA$(if ($PrivateData) {" $PrivateData"})
 
 #>
 "@


### PR DESCRIPTION
Several lines end up with trailing whitespace if a value is not provided. For instance, if no tags are provided, that line becomes `.TAGS ` (note the trailing whitespace). This violates default PSScriptAnalyzer rules, and is otherwise an inconvenience. This change will append the correct whitespace and the value if it's provided, and prevent extraneous whitespace from being added if no value is provided (as in the field is being left empty/blank).