### PR TITLE
Check for clobbered commands faster

### DIFF
--- a/src/PowerShellGet/private/functions/Validate-ModuleCommandAlreadyAvailable.ps1
+++ b/src/PowerShellGet/private/functions/Validate-ModuleCommandAlreadyAvailable.ps1
@@ -50,13 +50,14 @@ function Validate-ModuleCommandAlreadyAvailable
             # To avoid that, appending '*' at the end for each name then comparing the results.
             $CommandNames = $CurrentModuleInfo.ExportedCommands.Values.Name
 
-            # construct a regex matching any of the commands in this module.
-            $Matcher = [regex](($CommandNames | % { "($_)" }) -join "|")
+            # construct a hash with all of the commands in this module.
+            $CommandNameHash = @{}
+            $CommandNames | % { $CommandNameHash[$_] = 1 }
             
             $AvailableCommands = Microsoft.PowerShell.Core\Get-Command -Name *  `
                                                                       -ErrorAction Ignore `
                                                                       -WarningAction SilentlyContinue |
-                                    Microsoft.PowerShell.Core\Where-Object { ($Matcher.IsMatch($_.Name)) -and
+                                    Microsoft.PowerShell.Core\Where-Object { ($CommandNameHash.ContainsKey($_.Name)) -and
                                                                              ($_.ModuleName -ne $script:PSModuleProviderName) -and
                                                                              ($_.ModuleName -ne 'PSModule') -and
                                                                              ($_.ModuleName -ne $CurrentModuleInfo.Name) }

--- a/src/PowerShellGet/private/functions/Validate-ModuleCommandAlreadyAvailable.ps1
+++ b/src/PowerShellGet/private/functions/Validate-ModuleCommandAlreadyAvailable.ps1
@@ -46,15 +46,13 @@ function Validate-ModuleCommandAlreadyAvailable
         if(-not $InstalledModuleInfo -or -not $InstalledModuleInfo.ModuleBase.StartsWith($InstallLocation, [System.StringComparison]::OrdinalIgnoreCase))
         {
             # Throw an error if there is a command with the same name from a different source.
-            # Get-Command loads the module if a command is already available.
-            # To avoid that, appending '*' at the end for each name then comparing the results.
             $CommandNames = $CurrentModuleInfo.ExportedCommands.Values.Name
 
             # construct a hash with all of the commands in this module.
             $CommandNameHash = @{}
             $CommandNames | % { $CommandNameHash[$_] = 1 }
             
-            $AvailableCommands = Microsoft.PowerShell.Core\Get-Command -Name *  `
+            $AvailableCommands = Microsoft.PowerShell.Core\Get-Command  `
                                                                       -ErrorAction Ignore `
                                                                       -WarningAction SilentlyContinue |
                                     Microsoft.PowerShell.Core\Where-Object { ($CommandNameHash.ContainsKey($_.Name)) -and


### PR DESCRIPTION
installing awspowershell takes 309 seconds without this change, 33 seconds with it.

Need to test some more scenarios but this looks promising. Comments?