### PR TITLE
Warn when a repo is unreachable, don't produce a confusing error

### DIFF
--- a/Tests/PSGetPublishScript.Tests.ps1
+++ b/Tests/PSGetPublishScript.Tests.ps1
@@ -1080,7 +1080,7 @@ Describe PowerShell.PSGet.PublishScriptTests -Tags 'BVT','InnerLoop' {
         finally {
             Install-NuGetBinaries
         }
-    } -Skip:$($PSEdition -eq 'Core')
+    } -Skip:$($PSEdition -eq 'Core' -or $PSVersionTable.Version -lt '5.0.0')
 
     # Purpose: Validate that Publish-Script prompts to install NuGet.exe if NuGet.exe file is not found
     #
@@ -1138,7 +1138,7 @@ Describe PowerShell.PSGet.PublishScriptTests -Tags 'BVT','InnerLoop' {
         finally {
             Install-NuGetBinaries
         }
-    } -Skip:$($PSEdition -eq 'Core')
+    } -Skip:$($PSEdition -eq 'Core' -or $PSVersionTable.Version -lt '5.0.0')
 
     # Purpose: Validate that Publish-Module prompts to upgrade NuGet.exe if local NuGet.exe file is less than minimum required version
     #
@@ -1204,7 +1204,7 @@ Describe PowerShell.PSGet.PublishScriptTests -Tags 'BVT','InnerLoop' {
         finally {
             Install-NuGetBinaries
         }
-    } -Skip:$($PSEdition -eq 'Core')
+    } -Skip:$($PSEdition -eq 'Core' -or $PSVersionTable.Version -lt '5.0.0')
 
     # Purpose: Validate that Publish-Script prompts to install NuGet.exe if file not found
     #
@@ -1262,7 +1262,7 @@ Describe PowerShell.PSGet.PublishScriptTests -Tags 'BVT','InnerLoop' {
         finally {
             Install-NuGetBinaries
         }
-    } -Skip:$($PSEdition -eq 'Core')
+    } -Skip:$($PSEdition -eq 'Core' -or $PSVersionTable.Version -lt '5.0.0')
 }
 
 Describe PowerShell.PSGet.PublishScriptTests.P1 -Tags 'P1','OuterLoop' {

--- a/Tests/PSGetTestUtils.psm1
+++ b/Tests/PSGetTestUtils.psm1
@@ -149,9 +149,18 @@ function GetAndSet-PSGetTestGalleryDetails
     {
         $SourceUri        = 'http://localhost:8765/api/v2/'
         $psgetModule = Import-Module -Name PowerShellGet -PassThru -Scope Local
-        $ResolvedLocalSource = & $psgetModule Resolve-Location -Location $SourceUri -LocationParameterName 'SourceLocation'
 
-        if($ResolvedLocalSource -and 
+        # see if the localhost repo used in CI is present
+        $pingSuccess = $false
+        try
+        {
+            Invoke-WebRequest -Uri $SourceUri 
+            $pingSuccess = $true
+        } catch {
+
+        }
+
+        if($pingSuccess -and 
            $PSVersionTable.PSVersion -ge '5.0.0' -and 
            [System.Environment]::OSVersion.Version -ge "6.2.9200.0" -and 
            $PSCulture -eq 'en-US')

--- a/Tests/Pester.PSRepository.Tests.ps1
+++ b/Tests/Pester.PSRepository.Tests.ps1
@@ -249,24 +249,24 @@ Describe 'Managing repositories' -Tag BVT {
     It "Should let you register an unreachable repository but produce a warning" {
         # microsoft.com exists but doesn't host a nuget repo
         Register-PSRepository -Name NewRepo -SourceLocation "https://microsoft.com/api/v2" -WarningVariable warning -WarningAction SilentlyContinue
-        $warning | Should BeLike "*Unable to reach URL*"
+        $warning -join "" | Should BeLike "*Unable to reach URL*"
     }
     
     It "Should let you change a repo to an unreachable location but produce a warning" {
         Register-PSRepository -Name NewRepo -SourceLocation "https://www.microsoft.com/api/v2"-WarningAction SilentlyContinue
         Set-PSRepository -Name NewRepo -SourceLocation "https://docs.microsoft.com/api/v2" -WarningVariable warning -WarningAction SilentlyContinue
-        $warning | Should BeLike "*Unable to reach URL 'https://docs*"
+        $warning -join "" | Should BeLike "*Unable to reach URL 'https://docs*"
     }
 
     It "Should let you add a package source but produce a warning" {
         Register-PackageSource NewRepo -Location https://microsoft.com/api/v2 -ProviderName powershellget -WarningVariable warning -WarningAction SilentlyContinue
-        $warning | Should BeLike "*Unable to reach URL*"
+        $warning -join "" | Should BeLike "*Unable to reach URL*"
     }
 
     It "Should let you update a package source but produce a warning" {
         Register-PackageSource NewRepo -Location https://microsoft.com/api/v2 -ProviderName powershellget -WarningAction SilentlyContinue
         Set-PackageSource -Name NewRepo -Location https://microsoft.com/api/v2 -NewLocation https://docs.microsoft.com/api/v2 -ProviderName powershellget  -WarningVariable warning -WarningAction SilentlyContinue
-        $warning | Should BeLike "*Unable to reach URL 'https://docs*"
+        $warning -join "" | Should BeLike "*Unable to reach URL 'https://docs*"
     }
 
     It "Should not let you register 2 repositories which differ only by /" {

--- a/Tests/Pester.PSRepository.Tests.ps1
+++ b/Tests/Pester.PSRepository.Tests.ps1
@@ -289,17 +289,21 @@ Describe "Managing galleries while offline" -Tag BVT {
     }
 
     Context "Mock network failures" {
-        # Pinging any endpoint results in no response
+        # Pinging any endpoint results in no response. However this only affects the front-end of powershellget,
+        # not code running in the package provider, so it is not truly blocking all network access.
         Mock Ping-EndPoint -ModuleName powershellget {}
 
         It "Should let you unregister and reregister PSGallery" {
             Unregister-PSRepository PSGallery -WarningVariable unregisterWarning -WarningAction SilentlyContinue
             $unregisterWarning | Should Be $null
 
-            Register-PSRepository -Default -WarningAction SilentlyContinue -WarningVariable warning
+            Register-PSRepository -Default -WarningAction SilentlyContinue
             $defaultRepo = Get-PSRepository -Name PSGallery
             $DefaultRepo.SourceLocation | Should Be "https://www.powershellgallery.com/api/v2"
-            $warning -join "" | Should BeLike "*Unable to reach URL 'https://www.powershellgallery.com/api/v2'*"
+        }
+
+        It "Should let you trusted the gallery when it is unavailable" {
+            Set-PSRepository PSGallery -InstallationPolicy Trusted
         }
     }
 }

--- a/Tests/Pester.PSRepository.Tests.ps1
+++ b/Tests/Pester.PSRepository.Tests.ps1
@@ -249,13 +249,17 @@ Describe 'Managing repositories' -Tag BVT {
     It "Should let you register an unreachable repository but produce a warning" {
         # microsoft.com exists but doesn't host a nuget repo
         Register-PSRepository -Name NewRepo -SourceLocation "https://microsoft.com/api/v2" -WarningVariable warning -WarningAction SilentlyContinue
-        $warning -join "" | Should BeLike "*Unable to reach URL*"
+	    if($psversiontable.PSVersion -ge '5.0.0') { # -warningvariable doesn't seem to work in ps4?
+            $warning -join "" | Should BeLike "*Unable to reach URL*"
+        }
     }
     
     It "Should let you change a repo to an unreachable location but produce a warning" {
         Register-PSRepository -Name NewRepo -SourceLocation "https://www.microsoft.com/api/v2"-WarningAction SilentlyContinue
         Set-PSRepository -Name NewRepo -SourceLocation "https://docs.microsoft.com/api/v2" -WarningVariable warning -WarningAction SilentlyContinue
-        $warning -join "" | Should BeLike "*Unable to reach URL 'https://docs*"
+        if($psversiontable.PSVersion -ge '5.0.0') { # -warningvariable doesn't seem to work in ps4?
+            $warning -join "" | Should BeLike "*Unable to reach URL 'https://docs*"
+        }
     }
 
     It "Should let you add a package source but produce a warning" {

--- a/Tests/Pester.PSRepository.Tests.ps1
+++ b/Tests/Pester.PSRepository.Tests.ps1
@@ -302,7 +302,7 @@ Describe "Managing galleries while offline" -Tag BVT {
             $DefaultRepo.SourceLocation | Should Be "https://www.powershellgallery.com/api/v2"
         }
 
-        It "Should let you trusted the gallery when it is unavailable" {
+        It "Should let you trust the gallery even when it is unavailable" {
             Set-PSRepository PSGallery -InstallationPolicy Trusted
         }
     }

--- a/Tests/Pester.PSRepository.Tests.ps1
+++ b/Tests/Pester.PSRepository.Tests.ps1
@@ -263,6 +263,11 @@ Describe 'Managing repositories' -Tag BVT {
         $warning | Should BeLike "*Unable to reach URL*"
     }
 
+    It "Should let you update a package source but produce a warning" {
+        Register-PackageSource NewRepo -Location https://microsoft.com/api/v2 -ProviderName powershellget -WarningAction SilentlyContinue
+        Set-PackageSource -Name NewRepo -Location https://microsoft.com/api/v2 -NewLocation https://docs.microsoft.com/api/v2 -ProviderName powershellget  -WarningVariable warning -WarningAction SilentlyContinue
+        $warning | Should BeLike "*Unable to reach URL 'https://docs*"
+    }
 
     It "Should not let you register 2 repositories which differ only by /" {
         Register-PSRepository -Name NewRepo -SourceLocation "https://nowhere.com/api/v2" -WarningAction SilentlyContinue

--- a/Tests/Pester.PSRepository.Tests.ps1
+++ b/Tests/Pester.PSRepository.Tests.ps1
@@ -226,3 +226,33 @@ Describe 'Test Set-PSRepository and Set-PackageSource for PSGallery repository' 
     } `
     -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 }
+
+Describe 'Managing repositories' -Tag BVT {
+    BeforeAll {        
+	    Install-NuGetBinaries
+    }
+
+    AfterAll {    
+            
+    }
+
+    BeforeEach {
+        Unregister-PSRepository NewRepo -ErrorAction SilentlyContinue
+        Unregister-PSRepository NewRepoSlash -ErrorAction SilentlyContinue
+    }
+
+    AfterEach {
+        Unregister-PSRepository NewRepo -ErrorAction SilentlyContinue
+        Unregister-PSRepository NewRepoSlash -ErrorAction SilentlyContinue
+    }
+
+    It "Should let you register an unreachable repository but produce a warning" {
+        Register-PSRepository -Name NewRepo -SourceLocation "https://nowhere.com/api/v2" -WarningVariable warning -WarningAction SilentlyContinue
+        $warning | Should BeLike "*Unable to reach URL*"
+    }
+    
+    It "Should not let you register 2 repositories which differ only by /" {
+        Register-PSRepository -Name NewRepo -SourceLocation "https://nowhere.com/api/v2" -WarningAction SilentlyContinue
+        { Register-PSRepository -Name NewRepoSlash -SourceLocation "https://nowhere.com/api/v2/" -WarningAction SilentlyContinue } | Should -Throw
+    } -Skip
+}

--- a/Tests/Pester.PSRepository.Tests.ps1
+++ b/Tests/Pester.PSRepository.Tests.ps1
@@ -247,10 +247,23 @@ Describe 'Managing repositories' -Tag BVT {
     }
 
     It "Should let you register an unreachable repository but produce a warning" {
-        Register-PSRepository -Name NewRepo -SourceLocation "https://nowhere.com/api/v2" -WarningVariable warning -WarningAction SilentlyContinue
+        # microsoft.com exists but doesn't host a nuget repo
+        Register-PSRepository -Name NewRepo -SourceLocation "https://microsoft.com/api/v2" -WarningVariable warning -WarningAction SilentlyContinue
         $warning | Should BeLike "*Unable to reach URL*"
     }
     
+    It "Should let you change a repo to an unreachable location but produce a warning" {
+        Register-PSRepository -Name NewRepo -SourceLocation "https://www.microsoft.com/api/v2"-WarningAction SilentlyContinue
+        Set-PSRepository -Name NewRepo -SourceLocation "https://docs.microsoft.com/api/v2" -WarningVariable warning -WarningAction SilentlyContinue
+        $warning | Should BeLike "*Unable to reach URL 'https://docs*"
+    }
+
+    It "Should let you add a package source but produce a warning" {
+        Register-PackageSource NewRepo -Location https://microsoft.com/api/v2 -ProviderName powershellget -WarningVariable warning -WarningAction SilentlyContinue
+        $warning | Should BeLike "*Unable to reach URL*"
+    }
+
+
     It "Should not let you register 2 repositories which differ only by /" {
         Register-PSRepository -Name NewRepo -SourceLocation "https://nowhere.com/api/v2" -WarningAction SilentlyContinue
         { Register-PSRepository -Name NewRepoSlash -SourceLocation "https://nowhere.com/api/v2/" -WarningAction SilentlyContinue } | Should -Throw

--- a/src/PowerShellGet/PSGet.Resource.psd1
+++ b/src/PowerShellGet/PSGet.Resource.psd1
@@ -99,6 +99,7 @@ ConvertFrom-StringData @'
         FailedToPublish=Failed to publish module '{0}': '{1}'.
         PublishedSuccessfully=Successfully published module '{0}' to the module publish location '{1}'. Please allow few minutes for '{2}' to show up in the search results.
         InvalidWebUri=The specified Uri '{0}' for parameter '{1}' is an invalid Web Uri. Please ensure that it meets the Web Uri requirements.
+        WarnUnableToReachWebUri=Unable to reach URL at '{0}' for parameter '{1}'. Please check that the URL is correct.
         RepositoryAlreadyRegistered=The repository could not be registered because there exists a registered repository with Name '{0}' and SourceLocation '{1}'. To register another repository with Name '{2}', please unregister the existing repository using the Unregister-PSRepository cmdlet.
         RepositoryToBeUnregisteredNotFound=The repository '{0}' was not removed because no repository was found with that name. Please run Get-PSRepository and ensure that a repository of that name is present.
         RepositoryCannotBeUnregistered=The specified repository '{0}' cannot be unregistered.

--- a/src/PowerShellGet/PSGet.Resource.psd1
+++ b/src/PowerShellGet/PSGet.Resource.psd1
@@ -99,7 +99,7 @@ ConvertFrom-StringData @'
         FailedToPublish=Failed to publish module '{0}': '{1}'.
         PublishedSuccessfully=Successfully published module '{0}' to the module publish location '{1}'. Please allow few minutes for '{2}' to show up in the search results.
         InvalidWebUri=The specified Uri '{0}' for parameter '{1}' is an invalid Web Uri. Please ensure that it meets the Web Uri requirements.
-        WarnUnableToReachWebUri=Unable to reach URL '{0}'. Please check that the URL is correct.
+        WarnUnableToReachWebUri=Unable to reach URL '{0}'. Please check that the URL is correct and that Proxy and ProxyCredentials (if needed) are correct.
         RepositoryAlreadyRegistered=The repository could not be registered because there exists a registered repository with Name '{0}' and SourceLocation '{1}'. To register another repository with Name '{2}', please unregister the existing repository using the Unregister-PSRepository cmdlet.
         RepositoryToBeUnregisteredNotFound=The repository '{0}' was not removed because no repository was found with that name. Please run Get-PSRepository and ensure that a repository of that name is present.
         RepositoryCannotBeUnregistered=The specified repository '{0}' cannot be unregistered.

--- a/src/PowerShellGet/PSGet.Resource.psd1
+++ b/src/PowerShellGet/PSGet.Resource.psd1
@@ -99,7 +99,7 @@ ConvertFrom-StringData @'
         FailedToPublish=Failed to publish module '{0}': '{1}'.
         PublishedSuccessfully=Successfully published module '{0}' to the module publish location '{1}'. Please allow few minutes for '{2}' to show up in the search results.
         InvalidWebUri=The specified Uri '{0}' for parameter '{1}' is an invalid Web Uri. Please ensure that it meets the Web Uri requirements.
-        WarnUnableToReachWebUri=Unable to reach URL at '{0}' for parameter '{1}'. Please check that the URL is correct.
+        WarnUnableToReachWebUri=Unable to reach URL '{0}'. Please check that the URL is correct.
         RepositoryAlreadyRegistered=The repository could not be registered because there exists a registered repository with Name '{0}' and SourceLocation '{1}'. To register another repository with Name '{2}', please unregister the existing repository using the Unregister-PSRepository cmdlet.
         RepositoryToBeUnregisteredNotFound=The repository '{0}' was not removed because no repository was found with that name. Please run Get-PSRepository and ensure that a repository of that name is present.
         RepositoryCannotBeUnregistered=The specified repository '{0}' cannot be unregistered.

--- a/src/PowerShellGet/private/functions/Check-PSGalleryApiAvailability.ps1
+++ b/src/PowerShellGet/private/functions/Check-PSGalleryApiAvailability.ps1
@@ -62,11 +62,11 @@ function Check-PSGalleryApiAvailability
 
     # ping V2
     $res_v2 = Ping-Endpoint -Endpoint $PSGalleryV2ApiUri
-    if ($res_v2.ContainsKey($Script:ResponseUri))
+    if ($res_v2 -and $res_v2.ContainsKey($Script:ResponseUri))
     {
         $resolvedUri_v2 = $res_v2[$Script:ResponseUri]
     }
-    if ($res_v2.ContainsKey($Script:StatusCode))
+    if ($res_v2 -and $res_v2.ContainsKey($Script:StatusCode))
     {
         $statusCode_v2 = $res_v2[$Script:StatusCode]
     }
@@ -74,11 +74,11 @@ function Check-PSGalleryApiAvailability
 
     # ping V3
     $res_v3 = Ping-Endpoint -Endpoint $PSGalleryV3ApiUri
-    if ($res_v3.ContainsKey($Script:ResponseUri))
+    if ($res_v3 -and $res_v3.ContainsKey($Script:ResponseUri))
     {
         $resolvedUri_v3 = $res_v3[$Script:ResponseUri]
     }
-    if ($res_v3.ContainsKey($Script:StatusCode))
+    if ($res_v3 -and $res_v3.ContainsKey($Script:StatusCode))
     {
         $statusCode_v3 = $res_v3[$Script:StatusCode]
     }

--- a/src/PowerShellGet/private/functions/Get-DynamicParameters.ps1
+++ b/src/PowerShellGet/private/functions/Get-DynamicParameters.ps1
@@ -25,7 +25,6 @@ function Get-DynamicParameters
 
     # Ping and resolve the specified location
     $loc = Resolve-Location -Location $loc `
-                            -LocationParameterName 'Location' `
                             -ErrorAction SilentlyContinue `
                             -WarningAction SilentlyContinue
     if(-not $loc)

--- a/src/PowerShellGet/private/functions/Get-ScriptSourceLocation.ps1
+++ b/src/PowerShellGet/private/functions/Get-ScriptSourceLocation.ps1
@@ -43,7 +43,6 @@ function Get-ScriptSourceLocation
             {
                 # Ping and resolve the specified location
                 $scriptLocation = Resolve-Location -Location $tempScriptLocation `
-                                                   -LocationParameterName 'ScriptSourceLocation' `
                                                    -Credential $Credential `
                                                    -Proxy $Proxy `
                                                    -ProxyCredential $ProxyCredential `

--- a/src/PowerShellGet/private/functions/Get-ValidModuleLocation.ps1
+++ b/src/PowerShellGet/private/functions/Get-ValidModuleLocation.ps1
@@ -58,7 +58,7 @@ function Get-ValidModuleLocation
                                                  -Proxy $Proxy `
                                                  -ProxyCredential $ProxyCredential `
                                                  -ErrorAction SilentlyContinue `
-                                                 -WarningAction SilentlyContinue
+                                                 -SkipLocationWarning
                 if($tempLocation)
                 {
                    return $tempLocation
@@ -73,7 +73,8 @@ function Get-ValidModuleLocation
                                            -Credential $Credential `
                                            -Proxy $Proxy `
                                            -ProxyCredential $ProxyCredential `
-                                           -CallerPSCmdlet $PSCmdlet
+                                           -CallerPSCmdlet $PSCmdlet `
+                                           -SkipLocationWarning
     }
 
     return $LocationString

--- a/src/PowerShellGet/private/functions/Get-ValidModuleLocation.ps1
+++ b/src/PowerShellGet/private/functions/Get-ValidModuleLocation.ps1
@@ -58,7 +58,7 @@ function Get-ValidModuleLocation
                                                  -Proxy $Proxy `
                                                  -ProxyCredential $ProxyCredential `
                                                  -ErrorAction SilentlyContinue `
-                                                 -SkipLocationWarning
+                                                 -SkipLocationWarning                                               
                 if($tempLocation)
                 {
                    return $tempLocation
@@ -73,8 +73,7 @@ function Get-ValidModuleLocation
                                            -Credential $Credential `
                                            -Proxy $Proxy `
                                            -ProxyCredential $ProxyCredential `
-                                           -CallerPSCmdlet $PSCmdlet `
-                                           -SkipLocationWarning
+                                           -CallerPSCmdlet $PSCmdlet
     }
 
     return $LocationString

--- a/src/PowerShellGet/private/functions/Get-ValidModuleLocation.ps1
+++ b/src/PowerShellGet/private/functions/Get-ValidModuleLocation.ps1
@@ -53,7 +53,6 @@ function Get-ValidModuleLocation
             {
                 # Ping and resolve the specified location
                 $tempLocation = Resolve-Location -Location $tempLocation `
-                                                 -LocationParameterName $ParameterName `
                                                  -Credential $Credential `
                                                  -Proxy $Proxy `
                                                  -ProxyCredential $ProxyCredential `
@@ -69,7 +68,6 @@ function Get-ValidModuleLocation
 
         # Ping and resolve the specified location
         $LocationString = Resolve-Location -Location $LocationString `
-                                           -LocationParameterName $ParameterName `
                                            -Credential $Credential `
                                            -Proxy $Proxy `
                                            -ProxyCredential $ProxyCredential `

--- a/src/PowerShellGet/private/functions/Resolve-Location.ps1
+++ b/src/PowerShellGet/private/functions/Resolve-Location.ps1
@@ -73,8 +73,10 @@ function Resolve-Location
         else
         {
             # We couldn't reach the repo. Register it anyway but warn the user if we're able
+            # We'd like to include the parameter name here, but Register-PSRepository calls Add-PackageSource, 
+            # and both use different param names, so the parameter name becomes confusing
             if($CallerPSCmdlet -and -not $SkipLocationWarning) {
-                $message = $LocalizedData.WarnUnableToReachWebUri -f ($Location, $LocationParameterName)
+                $message = $LocalizedData.WarnUnableToReachWebUri -f ($Location)
                 Write-Warning $message
             }
             return $Location

--- a/src/PowerShellGet/private/functions/Resolve-Location.ps1
+++ b/src/PowerShellGet/private/functions/Resolve-Location.ps1
@@ -23,7 +23,11 @@ function Resolve-Location
 
         [Parameter()]
         [System.Management.Automation.PSCmdlet]
-        $CallerPSCmdlet
+        $CallerPSCmdlet,
+
+        [Parameter()]
+        [switch]
+        $SkipLocationWarning
     )
 
     # Ping and resolve the specified location
@@ -66,15 +70,14 @@ function Resolve-Location
         {
             return $resolvedLocation
         }
-        elseif($CallerPSCmdlet)
+        else
         {
-            $message = $LocalizedData.InvalidWebUri -f ($Location, $LocationParameterName)
-            ThrowError -ExceptionName "System.ArgumentException" `
-                       -ExceptionMessage $message `
-                       -ErrorId "InvalidWebUri" `
-                       -CallerPSCmdlet $CallerPSCmdlet `
-                       -ErrorCategory InvalidArgument `
-                       -ExceptionObject $Location
+            # We couldn't reach the repo. Register it anyway but warn the user if we're able
+            if($CallerPSCmdlet -and -not $SkipLocationWarning) {
+                $message = $LocalizedData.WarnUnableToReachWebUri -f ($Location, $LocationParameterName)
+                Write-Warning $message
+            }
+            return $Location
         }
     }
 }

--- a/src/PowerShellGet/private/functions/Resolve-Location.ps1
+++ b/src/PowerShellGet/private/functions/Resolve-Location.ps1
@@ -8,10 +8,6 @@ function Resolve-Location
         [string]
         $Location,
 
-        [Parameter(Mandatory=$true)]
-        [string]
-        $LocationParameterName,
-
         [Parameter()]
         $Credential,
 

--- a/src/PowerShellGet/private/functions/Set-PSGalleryRepository.ps1
+++ b/src/PowerShellGet/private/functions/Set-PSGalleryRepository.ps1
@@ -10,22 +10,26 @@ function Set-PSGalleryRepository
         $Proxy,
 
         [Parameter()]
-        $ProxyCredential
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.Management.Automation.PSCmdlet]
+        $CallerPSCmdlet
     )
 
     $psgalleryLocation = Resolve-Location -Location $Script:PSGallerySourceUri `
-                                          -LocationParameterName 'SourceLocation' `
                                           -Proxy $Proxy `
                                           -ProxyCredential $ProxyCredential `
-                                          -ErrorAction SilentlyContinue `
-                                          -WarningAction SilentlyContinue
+                                          -CallerPSCmdlet $CallerPSCmdlet `
+                                          -ErrorAction SilentlyContinue
+                                          
 
     $scriptSourceLocation = Resolve-Location -Location $Script:PSGalleryScriptSourceUri `
-                                             -LocationParameterName 'ScriptSourceLocation' `
                                              -Proxy $Proxy `
                                              -ProxyCredential $ProxyCredential `
-                                             -ErrorAction SilentlyContinue `
-                                             -WarningAction SilentlyContinue
+                                             -CallerPSCmdlet $CallerPSCmdlet `
+                                             -ErrorAction SilentlyContinue 
+                                              
     if($psgalleryLocation)
     {
         $result = Ping-Endpoint -Endpoint $Script:PSGalleryPublishUri -AllowAutoRedirect:$false -Proxy $Proxy -ProxyCredential $ProxyCredential

--- a/src/PowerShellGet/private/modulefile/PartOne.ps1
+++ b/src/PowerShellGet/private/modulefile/PartOne.ps1
@@ -122,12 +122,12 @@ $script:PSGetInstalledScripts = $null
 
 # Public PSGallery module source name and location
 $Script:PSGalleryModuleSource="PSGallery"
-$Script:PSGallerySourceUri  = 'https://go.microsoft.com/fwlink/?LinkID=397631&clcid=0x409'
-$Script:PSGalleryPublishUri = 'https://go.microsoft.com/fwlink/?LinkID=397527&clcid=0x409'
-$Script:PSGalleryScriptSourceUri = 'https://go.microsoft.com/fwlink/?LinkID=622995&clcid=0x409'
+$Script:PSGallerySourceUri  = 'https://www.powershellgallery.com/api/v2'
+$Script:PSGalleryPublishUri = 'https://www.powershellgallery.com/api/v2/package/'
+$Script:PSGalleryScriptSourceUri = 'https://www.powershellgallery.com/api/v2/items/psscript'
 
 # PSGallery V3 Source
-$Script:PSGalleryV3SourceUri = 'https://go.microsoft.com/fwlink/?LinkId=528403&clcid=0x409'
+$Script:PSGalleryV3SourceUri = 'https://www.powershellgallery.com/api/v3'
 
 $Script:PSGalleryV2ApiAvailable = $true
 $Script:PSGalleryV3ApiAvailable = $false

--- a/src/PowerShellGet/public/providerfunctions/Add-PackageSource.ps1
+++ b/src/PowerShellGet/public/providerfunctions/Add-PackageSource.ps1
@@ -247,7 +247,7 @@ function Add-PackageSource
     if($Name -eq $Script:PSGalleryModuleSource)
     {
         # Add or update the PSGallery repository
-        $repository = Set-PSGalleryRepository -Trusted:$Trusted
+        $repository = Set-PSGalleryRepository -Trusted:$Trusted -CallerPSCmdlet $PSCmdlet
 
         if($repository)
         {
@@ -262,7 +262,6 @@ function Add-PackageSource
     {
         # Ping and resolve the specified location
         $Location = Resolve-Location -Location $Location `
-                                     -LocationParameterName 'Location' `
                                      -Credential $Credential `
                                      -Proxy $Proxy `
                                      -ProxyCredential $ProxyCredential `

--- a/src/PowerShellGet/public/providerfunctions/Add-PackageSource.ps1
+++ b/src/PowerShellGet/public/providerfunctions/Add-PackageSource.ps1
@@ -266,13 +266,8 @@ function Add-PackageSource
                                      -Credential $Credential `
                                      -Proxy $Proxy `
                                      -ProxyCredential $ProxyCredential `
-                                     -CallerPSCmdlet $PSCmdlet
-    }
-
-    if(-not $Location)
-    {
-        # Above Resolve-Location function throws an error when it is not able to resolve a location
-        return
+                                     -CallerPSCmdlet $PSCmdlet `
+                                     -SkipLocationWarning # otherwise we get duplicate warnings for unreachable repos
     }
 
     if(-not (Microsoft.PowerShell.Management\Test-Path -Path $Location) -and

--- a/src/PowerShellGet/public/providerfunctions/Add-PackageSource.ps1
+++ b/src/PowerShellGet/public/providerfunctions/Add-PackageSource.ps1
@@ -266,8 +266,7 @@ function Add-PackageSource
                                      -Credential $Credential `
                                      -Proxy $Proxy `
                                      -ProxyCredential $ProxyCredential `
-                                     -CallerPSCmdlet $PSCmdlet `
-                                     -SkipLocationWarning # otherwise we get duplicate warnings for unreachable repos
+                                     -CallerPSCmdlet $PSCmdlet
     }
 
     if(-not (Microsoft.PowerShell.Management\Test-Path -Path $Location) -and

--- a/src/PowerShellGet/public/psgetfunctions/Get-PSRepository.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Get-PSRepository.ps1
@@ -12,11 +12,6 @@ function Get-PSRepository
         $Name
     )
 
-    Begin
-    {
-        Get-PSGalleryApiAvailability -Repository $Name
-    }
-
     Process
     {
         $PSBoundParameters["Provider"] = $script:PSModuleProviderName

--- a/src/PowerShellGet/public/psgetfunctions/Register-PSRepository.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Register-PSRepository.ps1
@@ -149,8 +149,9 @@ function Register-PSRepository
                                                -Credential $Credential `
                                                -Proxy $Proxy `
                                                -ProxyCredential $ProxyCredential `
-                                               -CallerPSCmdlet $PSCmdlet
-                                               
+                                               -CallerPSCmdlet $PSCmdlet `
+                                               -SkipLocationWarning
+
             $providerName = $null
 
             if($PackageManagementProvider)

--- a/src/PowerShellGet/public/psgetfunctions/Register-PSRepository.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Register-PSRepository.ps1
@@ -150,12 +150,7 @@ function Register-PSRepository
                                                -Proxy $Proxy `
                                                -ProxyCredential $ProxyCredential `
                                                -CallerPSCmdlet $PSCmdlet
-            if(-not $SourceLocation)
-            {
-                # Above Resolve-Location function throws an error when it is not able to resolve a location
-                return
-            }
-
+                                               
             $providerName = $null
 
             if($PackageManagementProvider)

--- a/src/PowerShellGet/public/psgetfunctions/Register-PSRepository.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Register-PSRepository.ps1
@@ -88,8 +88,6 @@ function Register-PSRepository
 
     Begin
     {
-        Get-PSGalleryApiAvailability -Repository $Name
-
         Install-NuGetClientBinaries -CallerPSCmdlet $PSCmdlet -Proxy $Proxy -ProxyCredential $ProxyCredential
 
         if($PackageManagementProvider)
@@ -145,7 +143,6 @@ function Register-PSRepository
 
             # Ping and resolve the specified location
             $SourceLocation = Resolve-Location -Location (Get-LocationString -LocationUri $SourceLocation) `
-                                               -LocationParameterName 'SourceLocation' `
                                                -Credential $Credential `
                                                -Proxy $Proxy `
                                                -ProxyCredential $ProxyCredential `

--- a/src/PowerShellGet/public/psgetfunctions/Set-PSRepository.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Set-PSRepository.ps1
@@ -121,7 +121,6 @@ function Set-PSRepository
         {
             # Ping and resolve the specified location
             $SourceLocation = Resolve-Location -Location (Get-LocationString -LocationUri $SourceLocation) `
-                                               -LocationParameterName 'SourceLocation' `
                                                -Credential $Credential `
                                                -Proxy $Proxy `
                                                -ProxyCredential $ProxyCredential `

--- a/src/PowerShellGet/public/psgetfunctions/Set-PSRepository.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Set-PSRepository.ps1
@@ -85,8 +85,6 @@ function Set-PSRepository
 
     Begin
     {
-        Get-PSGalleryApiAvailability -Repository $Name
-
         Install-NuGetClientBinaries -CallerPSCmdlet $PSCmdlet -Proxy $Proxy -ProxyCredential $ProxyCredential
 
         if($PackageManagementProvider)

--- a/src/PowerShellGet/public/psgetfunctions/Unregister-PSRepository.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Unregister-PSRepository.ps1
@@ -13,11 +13,6 @@ function Unregister-PSRepository
         $Name
     )
 
-    Begin
-    {
-        Get-PSGalleryApiAvailability -Repository $Name
-    }
-
     Process
     {
         $PSBoundParameters["Provider"] = $script:PSModuleProviderName


### PR DESCRIPTION
Partially addresses #317 by improving the message, and producing a non-blocking warning rather than an error