### PR TITLE
Remove unused code in Update-ScriptFileInfo

### DIFF
--- a/src/PowerShellGet/public/psgetfunctions/Update-ScriptFileInfo.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Update-ScriptFileInfo.ps1
@@ -330,7 +330,6 @@ function Update-ScriptFileInfo
 
         $PSScriptInfoString = Get-PSScriptInfoString @params
 
-        $requiresStrings = ""
         $requiresStrings = Get-RequiresString -RequiredModules $RequiredModules
 
         $DescriptionValue = if($Description) {$Description} else {$psscriptInfo.Description}
@@ -349,10 +348,6 @@ function Update-ScriptFileInfo
         $ScriptMetadataString += "`r`n"
         $ScriptMetadataString += $ScriptCommentHelpInfoString
         $ScriptMetadataString += "`r`nParam()`r`n`r`n"
-        if(-not $ScriptMetadataString)
-        {
-            return
-        }
 
         $tempScriptFilePath = Microsoft.PowerShell.Management\Join-Path -Path $script:TempPath -ChildPath "$(Get-Random).ps1"
 


### PR DESCRIPTION
The assigned value `""` is not used because it is replaced in the next line.
```powershell
$requiresStrings = ""
$requiresStrings = Get-RequiresString -RequiredModules $RequiredModules
```

The `if` statement is always `$false` because ```"`r`nParam()`r`n`r`n"``` is appended in the previous line.
```powershell
$ScriptMetadataString += "`r`nParam()`r`n`r`n"
if(-not $ScriptMetadataString)
{
	return
}
```
