### PR TITLE
Now removes the PSGet_ prepended to line 2 in the updated manifest.

### DIFF
--- a/src/PowerShellGet/public/psgetfunctions/Update-ModuleManifest.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Update-ModuleManifest.ps1
@@ -941,6 +941,9 @@ function Update-ModuleManifest
 
         $newContent = Microsoft.PowerShell.Management\Get-Content -Path $tempPath
 
+        #Remove the PSGet_ prepended to the original manifest name due to the temp file name
+        $newContent[1] = $newContent[1] -replace "'PSGet_", "'"
+
         try
         {
             #Ask for confirmation of the new manifest before replacing the original one


### PR DESCRIPTION
This resolves issue #402. A simple regex replace to remove PSGet_ in the module name on line 2.