### PR TITLE
Edyoung/issue 349 catastrophic

### DIFF
--- a/Tests/PSGetUpdateModule.Tests.ps1
+++ b/Tests/PSGetUpdateModule.Tests.ps1
@@ -91,19 +91,19 @@ Describe UpdateModuleFromAlternateRepo -Tags 'BVT' {
         PSGetTestUtils\Uninstall-Module ContosoClient
     }
 
-    It "Check situation" {
+    It "Check that removing a slash from a repo doesn't break update" {
         $withSlash = "https://www.poshtestgallery.com/api/v2/"
         $noSlash = "https://www.poshtestgallery.com/api/v2"
-        Write-Host (Get-PSRepository | Out-String)
+        #Write-Host (Get-PSRepository | Out-String)
         (Get-PSRepository PSGallery).SourceLocation | Should Be $withSlash
 
         Install-Module ContosoServer -RequiredVersion 1.0
         (Get-InstalledModule ContosoServer).RepositorySourceLocation | Should Be $withSlash
-        Write-Host (Get-InstalledModule ContosoServer -AllVersions | Format-List | Out-String)
+        #Write-Host (Get-InstalledModule ContosoServer -AllVersions | Format-List | Out-String)
 
         # now update where PSGallery Source Location is
         Set-PSGallerySourceLocation -Location $noSlash
-        Write-Host (Get-PSRepository | Out-String)
+        #Write-Host (Get-PSRepository | Out-String)
         (Get-PSRepository PSGallery).SourceLocation | Should Be $noSlash
 
         # reload powershellget to force-update cached repository info
@@ -111,11 +111,39 @@ Describe UpdateModuleFromAlternateRepo -Tags 'BVT' {
 
         # now try and update module isntalled using other SourceLocation
         Update-Module ContosoServer -RequiredVersion 2.0 -ErrorAction Stop
-        Write-Host (Get-InstalledModule ContosoServer -AllVersions | Format-List | Out-String)
+        #Write-Host (Get-InstalledModule ContosoServer -AllVersions | Format-List | Out-String)
         (Get-InstalledModule ContosoServer).RepositorySourceLocation | Should Be $noSlash
 
         (Get-InstalledModule ContosoServer).Version | Should Be 2.0
+    }
 
+    It "Check that adding a slash to a repo doesn't break update" {
+        $withSlash = "https://www.poshtestgallery.com/api/v2/"
+        $noSlash = "https://www.poshtestgallery.com/api/v2"
+        #Write-Host (Get-PSRepository | Out-String)
+
+        Set-PSGallerySourceLocation -Location $noSlash
+
+        (Get-PSRepository PSGallery).SourceLocation | Should Be $noSlash
+
+        Install-Module ContosoServer -RequiredVersion 1.0
+        (Get-InstalledModule ContosoServer).RepositorySourceLocation | Should Be $noSlash
+        #Write-Host (Get-InstalledModule ContosoServer -AllVersions | Format-List | Out-String)
+
+        # now update where PSGallery Source Location is
+        Set-PSGallerySourceLocation -Location $withSlash
+        #Write-Host (Get-PSRepository | Out-String)
+        (Get-PSRepository PSGallery).SourceLocation | Should Be $withSlash
+
+        # reload powershellget to force-update cached repository info
+        Import-Module PowerShellGet -Force
+
+        # now try and update module isntalled using other SourceLocation
+        Update-Module ContosoServer -RequiredVersion 2.0 -ErrorAction Stop
+        #Write-Host (Get-InstalledModule ContosoServer -AllVersions | Format-List | Out-String)
+        (Get-InstalledModule ContosoServer).RepositorySourceLocation | Should Be $withSlash
+
+        (Get-InstalledModule ContosoServer).Version | Should Be 2.0
     }
 }
 

--- a/Tests/PSGetUpdateModule.Tests.ps1
+++ b/Tests/PSGetUpdateModule.Tests.ps1
@@ -113,7 +113,6 @@ Describe UpdateModuleFromAlternateRepo -Tags 'BVT' {
         Update-Module ContosoServer -RequiredVersion 2.0 -ErrorAction Stop
         #Write-Host (Get-InstalledModule ContosoServer -AllVersions | Format-List | Out-String)
         (Get-InstalledModule ContosoServer).RepositorySourceLocation | Should Be $noSlash
-
         (Get-InstalledModule ContosoServer).Version | Should Be 2.0
     }
 
@@ -142,7 +141,6 @@ Describe UpdateModuleFromAlternateRepo -Tags 'BVT' {
         Update-Module ContosoServer -RequiredVersion 2.0 -ErrorAction Stop
         #Write-Host (Get-InstalledModule ContosoServer -AllVersions | Format-List | Out-String)
         (Get-InstalledModule ContosoServer).RepositorySourceLocation | Should Be $withSlash
-
         (Get-InstalledModule ContosoServer).Version | Should Be 2.0
     }
 }

--- a/src/PowerShellGet/private/functions/Get-SourceName.ps1
+++ b/src/PowerShellGet/private/functions/Get-SourceName.ps1
@@ -1,10 +1,9 @@
-function Get-SourceName
-{
+function Get-SourceName {
     [CmdletBinding()]
     [OutputType("string")]
     Param
     (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $Location
@@ -12,13 +11,11 @@ function Get-SourceName
 
     Set-ModuleSourcesVariable
 
-    foreach($psModuleSource in $script:PSGetModuleSources.Values)
-    {
-        if(($psModuleSource.Name -eq $Location) -or
-           ($psModuleSource.SourceLocation -eq $Location) -or
-           ((Get-Member -InputObject $psModuleSource -Name $script:ScriptSourceLocation) -and
-           ($psModuleSource.ScriptSourceLocation -eq $Location)))
-        {
+    foreach ($psModuleSource in $script:PSGetModuleSources.Values) {
+        if (($psModuleSource.Name -eq $Location) -or
+            (Test-EquivalentLocation -LocationA $psModuleSource.SourceLocation -LocationB $Location) -or
+            ((Get-Member -InputObject $psModuleSource -Name $script:ScriptSourceLocation) -and
+                (Test-EquivalentLocation -LocationA $psModuleSource.ScriptSourceLocation -LocationB $Location))) {
             return $psModuleSource.Name
         }
     }

--- a/src/PowerShellGet/private/functions/Test-EquivalentLocation.ps1
+++ b/src/PowerShellGet/private/functions/Test-EquivalentLocation.ps1
@@ -1,0 +1,18 @@
+
+# Compare 2 strings, ignoring any trailing slashes or backslashes.
+# This is not exactly the same as URL or path equivalence but it should work in practice
+function Test-EquivalentLocation {
+    [CmdletBinding()]
+    [OutputType("bool")]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$LocationA,
+
+        [Parameter(Mandatory = $false)]
+        [string]$LocationB
+    )
+
+    $LocationA = $LocationA.TrimEnd("\/")
+    $LocationB = $LocationB.TrimEnd("\/")
+    return $LocationA -eq $LocationB
+}


### PR DESCRIPTION
Should resolve #349 and #401 

When a module is installed, we store the SourceLocation at that time. When you run Update-Module, it looks for a source which matches that saved location. When the two do not match, the update fails. The expected URL for the PowerShellGallery is https://www.powershellgallery.com/api/v2 , but some operation (it is still not clear exactly what) has led to some users having the gallery URL as https://www.powershellgallery.com/api/v2/ - with a trailing /. 

This is treated as the same URL by the web server but is different-enough that Update-Module sees the saved and current repository sources as different.

This change makes it so that when we look for a repository by URL/path we ignore trailing / or \ characters when comparing them. This should resolve the practical issues people are hitting with Update-Module.