### PR TITLE
Fix for not being able to register PSGallery repository behind web proxy

### DIFF
--- a/src/PowerShellGet/private/functions/Resolve-Location.ps1
+++ b/src/PowerShellGet/private/functions/Resolve-Location.ps1
@@ -62,7 +62,7 @@ function Resolve-Location
 
         Write-Debug -Message "Ping-Endpoint: location=$Location, statuscode=$statusCode, resolvedLocation=$resolvedLocation"
 
-        if((($statusCode -eq 200) -or ($statusCode -eq 401)) -and $resolvedLocation)
+        if((($statusCode -eq 200) -or ($statusCode -eq 401) -or ($statusCode -eq 407)) -and $resolvedLocation)
         {
             return $resolvedLocation
         }


### PR DESCRIPTION
Added statusCode 407 (Proxy authentication required) as a valid return status code. Interestingly, 401 (Unauthorized) is already included.

Additional details can be found in the following comment
https://github.com/PowerShell/PowerShellGet/issues/350#issuecomment-457883539