### PR TITLE
Update-ModuleManifest can take an empty array of functions or cmdlets to export #409

### DIFF
--- a/Tests/PSGetUpdateModuleManifest.Tests.ps1
+++ b/Tests/PSGetUpdateModuleManifest.Tests.ps1
@@ -152,7 +152,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
     # Action:
     #      Update-ModuleManifest -Path [Path] 
     #
-    # Expected Result: The updated manifest should have the same DefaultCommandPreifx as before, 
+    # Expected Result: The updated manifest should have the same DefaultCommandPrefix as before, 
     # CmdletsToExport, FunctionsToExport, AliasesToExport, DSCResourcesToExport should not have prefixes affixed
     #                   
     It UpdateModuleManifestWithDefaultCommandPrefix {
@@ -197,6 +197,22 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         }
     }
 
+    # Purpose: Update a module manifest with an empty array of commandlets and functions to export
+    #
+    # Action: Update-ModuleManifest -Path [path] -CmdletsToExport "" -functions ""
+    #
+    # Expected Result: The updated module manifest should have no commandlets or functions to export
+    #
+    It "UpdateModuleManifestWithEmptyFunctionsAndCmdletsToExport" {
+        New-ModuleManifest  -Path $script:testManifestPath -Confirm:$false -CmdletsToExport "commandlet1","commandlet2" `
+                            -FunctionsToExport "function1","function2" -AliasesToExport "alias1","alias2"
+        Update-ModuleManifest -Path $script:testManifestPath -CmdletsToExport "" -FunctionsToExport "" -AliasesToExport ""
+        $updatedModuleInfo = Test-ModuleManifest -Path $script:testManifestPath
+
+        AssertEquals $updatedModuleInfo.FunctionsToExport.Count 0 "FunctionsToExport count should be 0"
+        AssertEquals $updatedModuleInfo.CmdletsToExport.Count 0 "CmdletsToExport count should be 0"
+        AssertEquals $updatedModuleInfo.AliasesToExport.Count 0 "AliasesToExport count should be 0"
+    }
 
 
     # Purpose: Update a module manifest with same parameters

--- a/src/PowerShellGet/public/psgetfunctions/Update-ModuleManifest.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Update-ModuleManifest.ps1
@@ -124,12 +124,10 @@ function Update-ModuleManifest
         $ModuleList,
 
         [Parameter()]
-        [ValidateNotNullOrEmpty()]
         [string[]]
         $FunctionsToExport,
 
         [Parameter()]
-        [ValidateNotNullOrEmpty()]
         [string[]]
         $AliasesToExport,
 
@@ -139,7 +137,6 @@ function Update-ModuleManifest
         $VariablesToExport,
 
         [Parameter()]
-        [ValidateNotNullOrEmpty()]
         [string[]]
         $CmdletsToExport,
 
@@ -497,7 +494,7 @@ function Update-ModuleManifest
         $params.Add("ModuleList",$ModuleManifestHashtable.ModuleList)
     }
 
-    if($FunctionsToExport)
+    if($FunctionsToExport -or $FunctionsToExport -is [array])
     {
         $params.Add("FunctionsToExport",$FunctionsToExport)
     }
@@ -523,7 +520,7 @@ function Update-ModuleManifest
         }
     }
 
-    if($AliasesToExport)
+    if($AliasesToExport -or $AliasesToExport -is [array])
     {
         $params.Add("AliasesToExport",$AliasesToExport)
     }
@@ -568,7 +565,7 @@ function Update-ModuleManifest
         }
     }
 
-    if($CmdletsToExport)
+    if($CmdletsToExport -or $CmdletsToExport -is [array])
     {
         $params.Add("CmdletsToExport", $CmdletsToExport)
     }


### PR DESCRIPTION
Fix for #409 