### PR TITLE
Fix Update-ModuleManifest clears FunctionsToExport, AliasesToExport, NestedModules #373

### DIFF
--- a/Tests/PSGetUpdateModuleManifest.Tests.ps1
+++ b/Tests/PSGetUpdateModuleManifest.Tests.ps1
@@ -155,7 +155,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
     #
     It UpdateModuleManifestWithNoAdditionalParameters3 {
 
-        New-ModuleManifest -Path $script:testManifestPath -ModuleVersion '1.0' -FunctionsToExport 'function1' -NestedModules 'module1' -AliasesToExport 'alias1'
+        New-ModuleManifest -Path $script:testManifestPath -ModuleVersion '1.0' -FunctionsToExport 'function1' -NestedModules 'Microsoft.PowerShell.Management' -AliasesToExport 'alias1'
         Update-ModuleManifest -Path $script:testManifestPath
 
         Import-LocalizedData -BindingVariable ModuleManifestHashTable `

--- a/Tests/PSGetUpdateModuleManifest.Tests.ps1
+++ b/Tests/PSGetUpdateModuleManifest.Tests.ps1
@@ -165,7 +165,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
                      -WarningAction SilentlyContinue
 
         AssertEquals $ModuleManifestHashTable.FunctionsToExport 'function1' "FunctionsToExport should be 'function1'"
-        AssertEquals $ModuleManifestHashTable.NestedModules 'module1' "NestedModules should be 'module1'"
+        AssertEquals $ModuleManifestHashTable.NestedModules 'Microsoft.PowerShell.Management' "NestedModules should be 'module1'"
         AssertEquals $ModuleManifestHashTable.AliasesToExport 'alias1' "AliasesToExport should be 'alias1'"
     } 
 

--- a/Tests/PSGetUpdateModuleManifest.Tests.ps1
+++ b/Tests/PSGetUpdateModuleManifest.Tests.ps1
@@ -118,7 +118,7 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
     # Action:
     #      Update-ModuleManifest -Path [Path] 
     #
-    # Expected Result: The updated manifest should have the same proerty values.
+    # Expected Result: The updated manifest should have the same property values.
     #
     It UpdateModuleManifestWithNoAdditionalParameters2 {    
 
@@ -144,6 +144,29 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
 
         AssertEquals $updatedModuleInfo.CompanyName $editedModuleInfo.CompanyName "Company name should be $expectedCompanyName"
         AssertEquals $($text.length) $expectedLength "Number of wildcards should be $expectedLength"
+    }
+
+    # Purpose: Validate Update-ModuleManifest will not reset original parameter values to default values
+    #
+    # Action:
+    #      Update-ModuleManifest -Path [Path]
+    #
+    # Expected Result: The updated manifest should have the same property values.
+    #
+    It UpdateModuleManifestWithNoAdditionalParameters3 {
+
+        New-ModuleManifest -Path $script:testManifestPath -ModuleVersion '1.0' -FunctionsToExport 'function1' -NestedModules 'module1' -AliasesToExport 'alias1'
+        Update-ModuleManifest -Path $script:testManifestPath
+
+        Import-LocalizedData -BindingVariable ModuleManifestHashTable `
+                     -FileName (Microsoft.PowerShell.Management\Split-Path $script:testManifestPath -Leaf) `
+                     -BaseDirectory (Microsoft.PowerShell.Management\Split-Path $script:testManifestPath -Parent) `
+                     -ErrorAction SilentlyContinue `
+                     -WarningAction SilentlyContinue
+
+        AssertEquals $ModuleManifestHashTable.FunctionsToExport 'function1' "FunctionsToExport should be 'function1'"
+        AssertEquals $ModuleManifestHashTable.NestedModules 'module1' "NestedModules should be 'module1'"
+        AssertEquals $ModuleManifestHashTable.AliasesToExport 'alias1' "AliasesToExport should be 'alias1'"
     } 
 
     # Purpose: Validate Update-ModuleManifest will keep the original property values for DefaultCommandPrefix,
@@ -213,7 +236,6 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         AssertEquals $updatedModuleInfo.CmdletsToExport.Count 0 "CmdletsToExport count should be 0"
         AssertEquals $updatedModuleInfo.AliasesToExport.Count 0 "AliasesToExport count should be 0"
     }
-
 
     # Purpose: Update a module manifest with same parameters
     #
@@ -651,7 +673,6 @@ Describe PowerShell.PSGet.UpdateModuleManifest -Tags 'BVT','InnerLoop' {
         }
         
     } 
-
 
     # Purpose: Validate Update-ModuleManifest will throw errors when there are paths defined in FilePath that are not in the module base
     #

--- a/src/PowerShellGet/public/psgetfunctions/Update-ModuleManifest.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Update-ModuleManifest.ps1
@@ -270,13 +270,9 @@ function Update-ModuleManifest
     {
         $params.Add("NestedModules",$NestedModules)
     }
-    elseif($moduleInfo.NestedModules)
+    elseif($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("NestedModules"))
     {
-        #Get the original module info from ManifestHashTab
-        if($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("NestedModules"))
-        {
-            $params.Add("NestedModules",$ModuleManifestHashtable.NestedModules)
-        }
+        $params.Add("NestedModules",$ModuleManifestHashtable.NestedModules)
     }
 
     #Guid is read-only property
@@ -519,6 +515,10 @@ function Update-ModuleManifest
             $params.Add("FunctionsToExport",($moduleInfo.ExportedFunctions.Keys -split ' '))
         }
     }
+    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("FunctionsToExport"))
+    {
+        $params.Add("FunctionsToExport", $ModuleManifestHashTable['FunctionsToExport'])
+    }
 
     if($AliasesToExport -or $AliasesToExport -is [array])
     {
@@ -544,6 +544,10 @@ function Update-ModuleManifest
         {
             $params.Add("AliasesToExport",($moduleInfo.ExportedAliases.Keys -split ' '))
         }
+    }
+    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("AliasesToExport"))
+    {
+        $params.Add("AliasesToExport", $ModuleManifestHashTable['AliasesToExport'])
     }
 
     if($VariablesToExport)
@@ -585,7 +589,7 @@ function Update-ModuleManifest
                 ForEach-Object { $parts = $_ -split '-', 2; $parts[-1] = $parts[-1] -replace "^$($moduleInfo.Prefix)"; $parts -join '-' }
             $params.Add("CmdletsToExport", $originalCmdlets)
         }
-        else 
+        else
         {
             $params.Add("CmdletsToExport",($moduleInfo.ExportedCmdlets.Keys -split ' '))
         }


### PR DESCRIPTION
This is a fix for #373 .

Update : I've written a comment on the issue which essentially say that this was resolved in a recent release of PowerShell. Should I close this PR ?