### PR TITLE
Add support for registering repositories with special chars

### DIFF
--- a/Tests/Pester.PSRepository.Tests.ps1
+++ b/Tests/Pester.PSRepository.Tests.ps1
@@ -60,6 +60,21 @@ Describe 'Test Register-PSRepository and Register-PackageSource for PSGallery re
         $repo.Trusted | should be $true
     }
 
+    It 'Register-PSRepository File system location with special chars' {
+        $tmpdir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath 'ps repo testing [$!@^&test(;)]'
+        if (-not (Test-Path -LiteralPath $tmpdir)) {
+            New-Item -Path $tmpdir -ItemType Directory > $null
+        }
+        try {
+            Register-PSRepository -Name $RepositoryName -SourceLocation $tmpdir
+            $repo = Get-PSRepository -Name $RepositoryName
+            $repo.Name | should be $RepositoryName
+            $repo.SourceLocation | should be $tmpdir
+        } finally {
+            Remove-Item -LiteralPath $tmpdir -Force -Recurse
+        }
+    }
+
     It 'Reregister PSGallery again: Should fail' {
         Register-PSRepository -Default
         Register-PSRepository -Default -ErrorVariable ev -ErrorAction SilentlyContinue

--- a/Tests/Pester.PSRepository.Tests.ps1
+++ b/Tests/Pester.PSRepository.Tests.ps1
@@ -66,10 +66,14 @@ Describe 'Test Register-PSRepository and Register-PackageSource for PSGallery re
             New-Item -Path $tmpdir -ItemType Directory > $null
         }
         try {
-            Register-PSRepository -Name $RepositoryName -SourceLocation $tmpdir
-            $repo = Get-PSRepository -Name $RepositoryName
-            $repo.Name | should be $RepositoryName
-            $repo.SourceLocation | should be $tmpdir
+            Register-PSRepository -Name 'Test Repo' -SourceLocation $tmpdir
+            try {
+                $repo = Get-PSRepository -Name 'Test Repo'
+                $repo.Name | should be 'Test Repo'
+                $repo.SourceLocation | should be $tmpdir
+            } finally {
+                Unregister-PSRepository -Name 'Test Repo' -ErrorAction SilentlyContinue
+            }
         } finally {
             Remove-Item -LiteralPath $tmpdir -Force -Recurse
         }

--- a/src/PowerShellGet/private/functions/Resolve-Location.ps1
+++ b/src/PowerShellGet/private/functions/Resolve-Location.ps1
@@ -29,7 +29,7 @@ function Resolve-Location
     # Ping and resolve the specified location
     if(-not (Test-WebUri -uri $Location))
     {
-        if(Microsoft.PowerShell.Management\Test-Path -Path $Location)
+        if(Microsoft.PowerShell.Management\Test-Path -LiteralPath $Location)
         {
             return $Location
         }

--- a/src/PowerShellGet/public/providerfunctions/Add-PackageSource.ps1
+++ b/src/PowerShellGet/public/providerfunctions/Add-PackageSource.ps1
@@ -106,7 +106,7 @@ function Add-PackageSource
 
         $PublishLocation = $Options[$script:PublishLocation]
 
-        if(-not (Microsoft.PowerShell.Management\Test-Path $PublishLocation) -and
+        if(-not (Microsoft.PowerShell.Management\Test-Path -LiteralPath $PublishLocation) -and
            -not (Test-WebUri -uri $PublishLocation))
         {
             $PublishLocationUri = [Uri]$PublishLocation
@@ -149,7 +149,7 @@ function Add-PackageSource
 
         $ScriptSourceLocation = $Options[$script:ScriptSourceLocation]
 
-        if(-not (Microsoft.PowerShell.Management\Test-Path $ScriptSourceLocation) -and
+        if(-not (Microsoft.PowerShell.Management\Test-Path -LiteralPath $ScriptSourceLocation) -and
            -not (Test-WebUri -uri $ScriptSourceLocation))
         {
             $ScriptSourceLocationUri = [Uri]$ScriptSourceLocation
@@ -192,7 +192,7 @@ function Add-PackageSource
 
         $ScriptPublishLocation = $Options[$script:ScriptPublishLocation]
 
-        if(-not (Microsoft.PowerShell.Management\Test-Path $ScriptPublishLocation) -and
+        if(-not (Microsoft.PowerShell.Management\Test-Path -LiteralPath $ScriptPublishLocation) -and
            -not (Test-WebUri -uri $ScriptPublishLocation))
         {
             $ScriptPublishLocationUri = [Uri]$ScriptPublishLocation
@@ -275,7 +275,7 @@ function Add-PackageSource
         return
     }
 
-    if(-not (Microsoft.PowerShell.Management\Test-Path -Path $Location) -and
+    if(-not (Microsoft.PowerShell.Management\Test-Path -LiteralPath $Location) -and
        -not (Test-WebUri -uri $Location) )
     {
         $LocationUri = [Uri]$Location
@@ -498,7 +498,7 @@ function Add-PackageSource
 
         # ScriptPublishLocation and PublishLocation should be equal in case of SMB Share or Local directory paths
         if($Options.ContainsKey($script:ScriptPublishLocation) -and
-           (Microsoft.PowerShell.Management\Test-Path -Path $ScriptPublishLocation))
+           (Microsoft.PowerShell.Management\Test-Path -LiteralPath $ScriptPublishLocation))
         {
             if($ScriptPublishLocation -ne $PublishLocation)
             {
@@ -521,7 +521,7 @@ function Add-PackageSource
     {
         # ScriptSourceLocation and SourceLocation cannot be same for they are URLs
         # Both should be equal in case of SMB Share or Local directory paths
-        if(Microsoft.PowerShell.Management\Test-Path -Path $ScriptSourceLocation)
+        if(Microsoft.PowerShell.Management\Test-Path -LiteralPath $ScriptSourceLocation)
         {
             if($ScriptSourceLocation -ne $LocationString)
             {


### PR DESCRIPTION
Fixes https://github.com/PowerShell/PowerShellGet/issues/441.

This allows you to use `Register-PSRepository` to register a file path that contains glob like characters like `[`.