### PR TITLE
Add SkipAutomaticTags Parameter to Publish-Module

### DIFF
--- a/Tests/PSGetPublishModule.Tests.ps1
+++ b/Tests/PSGetPublishModule.Tests.ps1
@@ -769,7 +769,7 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
     #
     # Expected Result: Publish operation should succeed and should have warned about tag length.
     #
-    It PublishModuleFunctionsAsTagsWarnWithoutEnforceMaximumTagLength {
+    It PublishModuleFunctionsAsTagsWarnWithoutSkipAutomaticTags {
         $version = "1.0.0"
         $Description = "$script:PublishModuleName module"
         $Tags = "PSGet","DSC"
@@ -801,13 +801,13 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
     } `
     -Skip:$($PSVersionTable.PSVersion -lt '5.0.0')
 
-    # Purpose: Test Publish-Module cmdlet excludes functions from tags when using EnforceMaximumTagLength parameter
+    # Purpose: Test Publish-Module cmdlet excludes functions from tags when using SkipAutomaticTags parameter
     #
-    # Action: Create a module manifest with PrivateData\PSData hashtable, try to publish with EnforceMaxmimumTagLength parameter
+    # Action: Create a module manifest with PrivateData\PSData hashtable, try to publish with SkipAutomaticTags parameter
     #
     # Expected Result: Publish operation should succeed and should not have warned about tag length
     #
-    It PublishModuleFunctionsAsTagsWithEnforceMaximumTagLength {
+    It PublishModuleFunctionsAsTagsWithSkipAutomaticTags {
         $version = "1.0.0"
         $Description = "$script:PublishModuleName module"
         $Tags = "PSGet","DSC"
@@ -832,7 +832,7 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
         Publish-Module -Path $script:PublishModuleBase `
                        -NuGetApiKey $script:ApiKey `
                        -Repository "PSGallery" `
-                       -EnforceMaximumTagLength `
+                       -SkipAutomaticTags `
                        -WarningAction SilentlyContinue `
                        -WarningVariable wa
 

--- a/src/PowerShellGet/private/functions/New-NuspecFile.ps1
+++ b/src/PowerShellGet/private/functions/New-NuspecFile.ps1
@@ -59,10 +59,9 @@ function New-NuspecFile {
     $packageElement = $xml.CreateElement("package", $nameSpaceUri)
     $metaDataElement = $xml.CreateElement("metadata", $nameSpaceUri)
 
-    #truncate tags if they exceed nuspec specifications for size.
-    $Tags = $Tags -Join " "
-
-    if ($Tags.Length -gt 4000) {
+    # warn we're over 4000 characters for standard nuget servers
+    $tagsString = $Tags -Join " "
+    if ($tagsString.Length -gt 4000) {
         Write-Warning -Message "Tag list exceeded 4000 characters and may not be accepted by some Nuget feeds."
     }
 

--- a/src/PowerShellGet/private/functions/New-NuspecFile.ps1
+++ b/src/PowerShellGet/private/functions/New-NuspecFile.ps1
@@ -74,7 +74,7 @@ function New-NuspecFile {
         releaseNotes             = $ReleaseNotes
         requireLicenseAcceptance = $RequireLicenseAcceptance.ToString().ToLower()
         copyright                = $Copyright
-        tags                     = $Tags
+        tags                     = $tagsString
     }
 
     if ($LicenseUrl) { $metaDataElementsHash.Add("licenseUrl", $LicenseUrl) }

--- a/src/PowerShellGet/private/functions/Publish-PSArtifactUtility.ps1
+++ b/src/PowerShellGet/private/functions/Publish-PSArtifactUtility.ps1
@@ -54,6 +54,10 @@ function Publish-PSArtifactUtility {
         $Tags,
 
         [Parameter(ParameterSetName = 'PublishModule')]
+        [switch]
+        $EnforceMaximumTagLength,
+
+        [Parameter(ParameterSetName = 'PublishModule')]
         [Uri]
         $LicenseUri,
 
@@ -218,7 +222,7 @@ function Publish-PSArtifactUtility {
     if ($PSScriptInfo) {
         $Tags += "PSScript"
 
-        if ($PSScriptInfo.DefinedCommands) {
+        if ($PSScriptInfo.DefinedCommands -and -not $EnforceMaximumTagLength) {
             if ($PSScriptInfo.DefinedFunctions) {
                 $Tags += "$($script:Includes)_Function"
                 $Tags += $PSScriptInfo.DefinedFunctions | Microsoft.PowerShell.Core\ForEach-Object { "$($script:Function)_$_" }
@@ -251,52 +255,54 @@ function Publish-PSArtifactUtility {
 
         $ModuleManifestHashTable = Get-ManifestHashTable -Path $ManifestPath
 
-        if ($PSModuleInfo.ExportedCommands.Count) {
-            if ($PSModuleInfo.ExportedCmdlets.Count) {
-                $Tags += "$($script:Includes)_Cmdlet"
-                $Tags += $PSModuleInfo.ExportedCmdlets.Keys | Microsoft.PowerShell.Core\ForEach-Object { "$($script:Cmdlet)_$_" }
+        if (-not $EnforceMaximumTagLength) {
+            if ($PSModuleInfo.ExportedCommands.Count) {
+                if ($PSModuleInfo.ExportedCmdlets.Count) {
+                    $Tags += "$($script:Includes)_Cmdlet"
+                    $Tags += $PSModuleInfo.ExportedCmdlets.Keys | Microsoft.PowerShell.Core\ForEach-Object { "$($script:Cmdlet)_$_" }
 
-                #if CmdletsToExport field in manifest file is "*", we suggest the user to include all those cmdlets for best practice
-                if ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey('CmdletsToExport') -and ($ModuleManifestHashTable.CmdletsToExport -eq "*")) {
-                    $WarningMessage = $LocalizedData.ShouldIncludeCmdletsToExport -f ($ManifestPath)
+                    #if CmdletsToExport field in manifest file is "*", we suggest the user to include all those cmdlets for best practice
+                    if ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey('CmdletsToExport') -and ($ModuleManifestHashTable.CmdletsToExport -eq "*")) {
+                        $WarningMessage = $LocalizedData.ShouldIncludeCmdletsToExport -f ($ManifestPath)
+                        Write-Warning -Message $WarningMessage
+                    }
+                }
+
+                if ($PSModuleInfo.ExportedFunctions.Count) {
+                    $Tags += "$($script:Includes)_Function"
+                    $Tags += $PSModuleInfo.ExportedFunctions.Keys | Microsoft.PowerShell.Core\ForEach-Object { "$($script:Function)_$_" }
+
+                    if ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey('FunctionsToExport') -and ($ModuleManifestHashTable.FunctionsToExport -eq "*")) {
+                        $WarningMessage = $LocalizedData.ShouldIncludeFunctionsToExport -f ($ManifestPath)
+                        Write-Warning -Message $WarningMessage
+                    }
+                }
+
+                $Tags += $PSModuleInfo.ExportedCommands.Keys | Microsoft.PowerShell.Core\ForEach-Object { "$($script:Command)_$_" }
+            }
+
+            $dscResourceNames = Get-ExportedDscResources -PSModuleInfo $PSModuleInfo
+            if ($dscResourceNames) {
+                $Tags += "$($script:Includes)_DscResource"
+
+                $Tags += $dscResourceNames | Microsoft.PowerShell.Core\ForEach-Object { "$($script:DscResource)_$_" }
+
+                #If DscResourcesToExport is commented out or "*" is used, we will write-warning
+                if ($ModuleManifestHashTable -and
+                    ($ModuleManifestHashTable.ContainsKey("DscResourcesToExport") -and
+                        $ModuleManifestHashTable.DscResourcesToExport -eq "*") -or
+                    -not $ModuleManifestHashTable.ContainsKey("DscResourcesToExport")) {
+                    $WarningMessage = $LocalizedData.ShouldIncludeDscResourcesToExport -f ($ManifestPath)
                     Write-Warning -Message $WarningMessage
                 }
             }
 
-            if ($PSModuleInfo.ExportedFunctions.Count) {
-                $Tags += "$($script:Includes)_Function"
-                $Tags += $PSModuleInfo.ExportedFunctions.Keys | Microsoft.PowerShell.Core\ForEach-Object { "$($script:Function)_$_" }
+            $RoleCapabilityNames = Get-AvailableRoleCapabilityName -PSModuleInfo $PSModuleInfo
+            if ($RoleCapabilityNames) {
+                $Tags += "$($script:Includes)_RoleCapability"
 
-                if ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey('FunctionsToExport') -and ($ModuleManifestHashTable.FunctionsToExport -eq "*")) {
-                    $WarningMessage = $LocalizedData.ShouldIncludeFunctionsToExport -f ($ManifestPath)
-                    Write-Warning -Message $WarningMessage
-                }
+                $Tags += $RoleCapabilityNames | Microsoft.PowerShell.Core\ForEach-Object { "$($script:RoleCapability)_$_" }
             }
-
-            $Tags += $PSModuleInfo.ExportedCommands.Keys | Microsoft.PowerShell.Core\ForEach-Object { "$($script:Command)_$_" }
-        }
-
-        $dscResourceNames = Get-ExportedDscResources -PSModuleInfo $PSModuleInfo
-        if ($dscResourceNames) {
-            $Tags += "$($script:Includes)_DscResource"
-
-            $Tags += $dscResourceNames | Microsoft.PowerShell.Core\ForEach-Object { "$($script:DscResource)_$_" }
-
-            #If DscResourcesToExport is commented out or "*" is used, we will write-warning
-            if ($ModuleManifestHashTable -and
-                ($ModuleManifestHashTable.ContainsKey("DscResourcesToExport") -and
-                    $ModuleManifestHashTable.DscResourcesToExport -eq "*") -or
-                -not $ModuleManifestHashTable.ContainsKey("DscResourcesToExport")) {
-                $WarningMessage = $LocalizedData.ShouldIncludeDscResourcesToExport -f ($ManifestPath)
-                Write-Warning -Message $WarningMessage
-            }
-        }
-
-        $RoleCapabilityNames = Get-AvailableRoleCapabilityName -PSModuleInfo $PSModuleInfo
-        if ($RoleCapabilityNames) {
-            $Tags += "$($script:Includes)_RoleCapability"
-
-            $Tags += $RoleCapabilityNames | Microsoft.PowerShell.Core\ForEach-Object { "$($script:RoleCapability)_$_" }
         }
 
         # Populate the module dependencies elements from RequiredModules and

--- a/src/PowerShellGet/private/functions/Publish-PSArtifactUtility.ps1
+++ b/src/PowerShellGet/private/functions/Publish-PSArtifactUtility.ps1
@@ -55,7 +55,7 @@ function Publish-PSArtifactUtility {
 
         [Parameter(ParameterSetName = 'PublishModule')]
         [switch]
-        $EnforceMaximumTagLength,
+        $SkipAutomaticTags,
 
         [Parameter(ParameterSetName = 'PublishModule')]
         [Uri]
@@ -222,7 +222,7 @@ function Publish-PSArtifactUtility {
     if ($PSScriptInfo) {
         $Tags += "PSScript"
 
-        if ($PSScriptInfo.DefinedCommands -and -not $EnforceMaximumTagLength) {
+        if ($PSScriptInfo.DefinedCommands -and -not $SkipAutomaticTags) {
             if ($PSScriptInfo.DefinedFunctions) {
                 $Tags += "$($script:Includes)_Function"
                 $Tags += $PSScriptInfo.DefinedFunctions | Microsoft.PowerShell.Core\ForEach-Object { "$($script:Function)_$_" }
@@ -255,7 +255,7 @@ function Publish-PSArtifactUtility {
 
         $ModuleManifestHashTable = Get-ManifestHashTable -Path $ManifestPath
 
-        if (-not $EnforceMaximumTagLength) {
+        if (-not $SkipAutomaticTags) {
             if ($PSModuleInfo.ExportedCommands.Count) {
                 if ($PSModuleInfo.ExportedCmdlets.Count) {
                     $Tags += "$($script:Includes)_Cmdlet"

--- a/src/PowerShellGet/public/psgetfunctions/Publish-Module.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Publish-Module.ps1
@@ -76,7 +76,11 @@ function Publish-Module {
 
         [Parameter(ParameterSetName = "ModuleNameParameterSet")]
         [switch]
-        $AllowPrerelease
+        $AllowPrerelease,
+
+        [Parameter()]
+        [switch]
+        $EnforceMaximumTagLength
     )
 
     Begin {
@@ -541,22 +545,23 @@ function Publish-Module {
             $shouldProcessMessage = $LocalizedData.PublishModulewhatIfMessage -f ($moduleInfo.Version, $moduleInfo.Name)
             if ($Force -or $PSCmdlet.ShouldProcess($shouldProcessMessage, "Publish-Module")) {
                 $PublishPSArtifactUtility_Params = @{
-                    PSModuleInfo     = $moduleInfo
-                    ManifestPath     = $manifestPath
-                    NugetApiKey      = $NuGetApiKey
-                    Destination      = $DestinationLocation
-                    Repository       = $Repository
-                    NugetPackageRoot = $tempModulePath
-                    FormatVersion    = $FormatVersion
-                    ReleaseNotes     = $($ReleaseNotes -join "`r`n")
-                    Tags             = $Tags
-                    LicenseUri       = $LicenseUri
-                    IconUri          = $IconUri
-                    ProjectUri       = $ProjectUri
-                    Verbose          = $VerbosePreference
-                    WarningAction    = $WarningPreference
-                    ErrorAction      = $ErrorActionPreference
-                    Debug            = $DebugPreference
+                    PSModuleInfo            = $moduleInfo
+                    ManifestPath            = $manifestPath
+                    NugetApiKey             = $NuGetApiKey
+                    Destination             = $DestinationLocation
+                    Repository              = $Repository
+                    NugetPackageRoot        = $tempModulePath
+                    FormatVersion           = $FormatVersion
+                    ReleaseNotes            = $($ReleaseNotes -join "`r`n")
+                    Tags                    = $Tags
+                    EnforceMaximumTagLength = $EnforceMaximumTagLength
+                    LicenseUri              = $LicenseUri
+                    IconUri                 = $IconUri
+                    ProjectUri              = $ProjectUri
+                    Verbose                 = $VerbosePreference
+                    WarningAction           = $WarningPreference
+                    ErrorAction             = $ErrorActionPreference
+                    Debug                   = $DebugPreference
                 }
                 if ($PSBoundParameters.Containskey('Credential')) {
                     $PublishPSArtifactUtility_Params.Add('Credential', $Credential)

--- a/src/PowerShellGet/public/psgetfunctions/Publish-Module.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Publish-Module.ps1
@@ -80,7 +80,7 @@ function Publish-Module {
 
         [Parameter()]
         [switch]
-        $EnforceMaximumTagLength
+        $SkipAutomaticTags
     )
 
     Begin {
@@ -141,8 +141,7 @@ function Publish-Module {
 
         if (-not $DestinationLocation -or
             (-not (Microsoft.PowerShell.Management\Test-Path $DestinationLocation) -and
-                -not (Test-WebUri -uri $DestinationLocation)))
-        {
+                -not (Test-WebUri -uri $DestinationLocation))) {
             $message = $LocalizedData.PSGalleryPublishLocationIsMissing -f ($Repository, $Repository)
             ThrowError -ExceptionName "System.ArgumentException" `
                 -ExceptionMessage $message `
@@ -374,12 +373,12 @@ function Publish-Module {
         # This finds all the items without force (leaving out hidden files and dirs) then copies them
         Microsoft.PowerShell.Management\Get-ChildItem $Path -recurse |
             Microsoft.PowerShell.Management\Copy-Item -Force -Confirm:$false -WhatIf:$false -Destination {
-                if ($_.PSIsContainer) {
-                    Join-Path $tempModulePathForFormatVersion $_.Parent.FullName.substring($path.length)
-                }
-                else {
-                    join-path $tempModulePathForFormatVersion $_.FullName.Substring($path.Length)
-                }
+            if ($_.PSIsContainer) {
+                Join-Path $tempModulePathForFormatVersion $_.Parent.FullName.substring($path.length)
+            }
+            else {
+                join-path $tempModulePathForFormatVersion $_.FullName.Substring($path.Length)
+            }
         }
 
         try {
@@ -545,23 +544,23 @@ function Publish-Module {
             $shouldProcessMessage = $LocalizedData.PublishModulewhatIfMessage -f ($moduleInfo.Version, $moduleInfo.Name)
             if ($Force -or $PSCmdlet.ShouldProcess($shouldProcessMessage, "Publish-Module")) {
                 $PublishPSArtifactUtility_Params = @{
-                    PSModuleInfo            = $moduleInfo
-                    ManifestPath            = $manifestPath
-                    NugetApiKey             = $NuGetApiKey
-                    Destination             = $DestinationLocation
-                    Repository              = $Repository
-                    NugetPackageRoot        = $tempModulePath
-                    FormatVersion           = $FormatVersion
-                    ReleaseNotes            = $($ReleaseNotes -join "`r`n")
-                    Tags                    = $Tags
-                    EnforceMaximumTagLength = $EnforceMaximumTagLength
-                    LicenseUri              = $LicenseUri
-                    IconUri                 = $IconUri
-                    ProjectUri              = $ProjectUri
-                    Verbose                 = $VerbosePreference
-                    WarningAction           = $WarningPreference
-                    ErrorAction             = $ErrorActionPreference
-                    Debug                   = $DebugPreference
+                    PSModuleInfo      = $moduleInfo
+                    ManifestPath      = $manifestPath
+                    NugetApiKey       = $NuGetApiKey
+                    Destination       = $DestinationLocation
+                    Repository        = $Repository
+                    NugetPackageRoot  = $tempModulePath
+                    FormatVersion     = $FormatVersion
+                    ReleaseNotes      = $($ReleaseNotes -join "`r`n")
+                    Tags              = $Tags
+                    SkipAutomaticTags = $SkipAutomaticTags
+                    LicenseUri        = $LicenseUri
+                    IconUri           = $IconUri
+                    ProjectUri        = $ProjectUri
+                    Verbose           = $VerbosePreference
+                    WarningAction     = $WarningPreference
+                    ErrorAction       = $ErrorActionPreference
+                    Debug             = $DebugPreference
                 }
                 if ($PSBoundParameters.Containskey('Credential')) {
                     $PublishPSArtifactUtility_Params.Add('Credential', $Credential)


### PR DESCRIPTION
When using a generic NuGet Server there is a hard coded 4000 character limit. Publish-Module gets a list of exported functions from the module manifest. If there are a lot of functions exported, publishing to a generic NuGet Server fails with an error stating: A nuget package's Tags property may not be more than 4000 characters long. This PR is to resolve issue #344.

The -EnforceMaximumTagLength switch removes commands and resources from being included as tags when present. This switch was added to Publish-Module and Publish-PSArtificateUtility.

I'm open to discussion on how the switch functions. I don't really have much of a preference - I just need the module to publish successfully.

I also wasn't sure where the help documentation was located, so that still needs to be added.