### PR TITLE
fix#191 update publish-module to allow exclude files.

### DIFF
--- a/Tests/PSGetPublishModule.Tests.ps1
+++ b/Tests/PSGetPublishModule.Tests.ps1
@@ -134,7 +134,7 @@ Describe PowerShell.PSGet.PublishModuleTests -Tags 'BVT','InnerLoop' {
     #
     # Expected Result: should be able to publish a module
     #
-    It PublishModuleWithNameForSxSVersion {
+    It "PublishModuleWithNameForSxSVersion" {
         $version = "2.0.0.0"
         $semanticVersion = '2.0.0'
         RemoveItem "$script:PublishModuleBase\*"

--- a/src/PowerShellGet/private/functions/Publish-PSArtifactUtility.ps1
+++ b/src/PowerShellGet/private/functions/Publish-PSArtifactUtility.ps1
@@ -63,7 +63,11 @@ function Publish-PSArtifactUtility {
 
         [Parameter(ParameterSetName = 'PublishModule')]
         [Uri]
-        $ProjectUri
+        $ProjectUri,
+
+        [Parameter(ParameterSetName = 'PublishModule')]
+        [string[]]
+        $Exclude
     )
 
     Install-NuGetClientBinaries -CallerPSCmdlet $PSCmdlet -BootstrapNuGetExe
@@ -203,6 +207,11 @@ function Publish-PSArtifactUtility {
         }
     }
 
+    $nuspecFiles = ""
+    if ($Exclude) {
+        $nuspecFileExcludePattern = $Exclude -Join ";"
+        $nuspecFiles = @{ src = "**/*.*"; exclude = $nuspecFileExcludePattern }
+    }
 
     # Add PSModule and PSGet format version tags
     if (-not $Tags) {
@@ -366,6 +375,10 @@ function Publish-PSArtifactUtility {
         ProjectUrl               = $ProjectUri
         IconUrl                  = $IconUri
         Dependencies             = $dependencies
+    }
+
+    if ($nuspecFiles) {
+        $params.Add('Files', $nuspecFiles)
     }
 
     try {

--- a/src/PowerShellGet/public/psgetfunctions/Publish-Module.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Publish-Module.ps1
@@ -70,6 +70,11 @@ function Publish-Module {
         [Uri]
         $ProjectUri,
 
+        [Parameter(ParameterSetName = "ModuleNameParameterSet")]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        $Exclude,
+
         [Parameter()]
         [switch]
         $Force,
@@ -137,8 +142,7 @@ function Publish-Module {
 
         if (-not $DestinationLocation -or
             (-not (Microsoft.PowerShell.Management\Test-Path $DestinationLocation) -and
-                -not (Test-WebUri -uri $DestinationLocation)))
-        {
+                -not (Test-WebUri -uri $DestinationLocation))) {
             $message = $LocalizedData.PSGalleryPublishLocationIsMissing -f ($Repository, $Repository)
             ThrowError -ExceptionName "System.ArgumentException" `
                 -ExceptionMessage $message `
@@ -370,12 +374,12 @@ function Publish-Module {
         # This finds all the items without force (leaving out hidden files and dirs) then copies them
         Microsoft.PowerShell.Management\Get-ChildItem $Path -recurse |
             Microsoft.PowerShell.Management\Copy-Item -Force -Confirm:$false -WhatIf:$false -Destination {
-                if ($_.PSIsContainer) {
-                    Join-Path $tempModulePathForFormatVersion $_.Parent.FullName.substring($path.length)
-                }
-                else {
-                    join-path $tempModulePathForFormatVersion $_.FullName.Substring($path.Length)
-                }
+            if ($_.PSIsContainer) {
+                Join-Path $tempModulePathForFormatVersion $_.Parent.FullName.substring($path.length)
+            }
+            else {
+                join-path $tempModulePathForFormatVersion $_.FullName.Substring($path.Length)
+            }
         }
 
         try {
@@ -560,6 +564,9 @@ function Publish-Module {
                 }
                 if ($PSBoundParameters.Containskey('Credential')) {
                     $PublishPSArtifactUtility_Params.Add('Credential', $Credential)
+                }
+                if ($Exclude) {
+                    $PublishPSArtifactUtility_Params.Add('Exclude', $Exclude)
                 }
                 Publish-PSArtifactUtility @PublishPSArtifactUtility_Params
             }


### PR DESCRIPTION
Assumes only one File tag is created in the nuspec scooping up everything in the directory, but multiple exclude glob patterns can be provided. 
Changes to nuspec creation to allow this were already made in #fix335