### PR TITLE
Issue 340 - Prefer Trusted Repositories

### DIFF
--- a/Tests/Pester.PSRepository.Tests.ps1
+++ b/Tests/Pester.PSRepository.Tests.ps1
@@ -40,6 +40,22 @@ Describe 'Test Register-PSRepository and Register-PackageSource for PSGallery re
         $repo.Trusted | should be $true
     }
 
+    It 'Get-PSRepository: Should return trusted before untrused' {
+        Register-PSRepository -Default
+
+        Set-PSRepository -Name $RepositoryName -InstallationPolicy 'Untrusted'
+
+        $repos = Get-PSRepository
+        $repos.InstallationPolicy | Should -Contain 'Trusted'
+        $repos.InstallationPolicy | Should -Contain 'Untrusted'
+
+        $orderedRepos = $repos | Sort-Object -Property 'InstallationPolicy' | Sort-Object -Property Name
+        for ($i = 0; $i -lt $repos.Count; $i++) {
+            $repos[$i].Name | Should -Be $orderedRepos[$i].Name
+            $repos[$i].InstallationPolicy | Should -Be $orderedRepos[$i].InstallationPolicy
+        }
+    }
+
     It 'Register-PSRepository -Default: Should work' {
         Register-PSRepository -Default
         $repo = Get-PSRepository $RepositoryName
@@ -72,10 +88,12 @@ Describe 'Test Register-PSRepository and Register-PackageSource for PSGallery re
                 $repo = Get-PSRepository -Name 'Test Repo'
                 $repo.Name | should be 'Test Repo'
                 $repo.SourceLocation | should be $tmpdir
-            } finally {
+            }
+            finally {
                 Unregister-PSRepository -Name 'Test Repo' -ErrorAction SilentlyContinue
             }
-        } finally {
+        }
+        finally {
             Remove-Item -LiteralPath $tmpdir -Force -Recurse
         }
     }

--- a/Tests/Pester.PSRepository.Tests.ps1
+++ b/Tests/Pester.PSRepository.Tests.ps1
@@ -46,8 +46,8 @@ Describe 'Test Register-PSRepository and Register-PackageSource for PSGallery re
         Set-PSRepository -Name $RepositoryName -InstallationPolicy 'Untrusted'
 
         $repos = Get-PSRepository
-        $repos.InstallationPolicy | Should -Contain 'Trusted'
-        $repos.InstallationPolicy | Should -Contain 'Untrusted'
+        { $repos.InstallationPolicy -contains 'Trusted' } | Should -Be $true
+        { $repos.InstallationPolicy -contains 'Untrusted' } | Should -Be $true
 
         $orderedRepos = $repos | Sort-Object -Property 'InstallationPolicy' | Sort-Object -Property Name
         for ($i = 0; $i -lt $repos.Count; $i++) {

--- a/src/PowerShellGet/public/psgetfunctions/Get-PSRepository.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Get-PSRepository.ps1
@@ -18,19 +18,25 @@ function Get-PSRepository {
         $PSBoundParameters["Provider"] = $script:PSModuleProviderName
         $PSBoundParameters["MessageResolver"] = $script:PackageManagementMessageResolverScriptBlock
 
+        $repositories = @()
+
         if ($Name) {
             foreach ($sourceName in $Name) {
                 $PSBoundParameters["Name"] = $sourceName
 
                 $packageSources = PackageManagement\Get-PackageSource @PSBoundParameters
 
-                $packageSources | Microsoft.PowerShell.Core\ForEach-Object { New-ModuleSourceFromPackageSource -PackageSource $_ }
+                $repositories += $packageSources | Microsoft.PowerShell.Core\ForEach-Object { New-ModuleSourceFromPackageSource -PackageSource $_ }
             }
         }
         else {
             $packageSources = PackageManagement\Get-PackageSource @PSBoundParameters
 
-            $packageSources | Microsoft.PowerShell.Core\ForEach-Object { New-ModuleSourceFromPackageSource -PackageSource $_ }
+            $repositories += $packageSources | Microsoft.PowerShell.Core\ForEach-Object { New-ModuleSourceFromPackageSource -PackageSource $_ }
         }
+
+        $repositories |
+            Microsoft.PowerShell.Utility\Sort-Object -Property IsTrusted -Descending |
+            Microsoft.PowerShell.Utility\Sort-Object -Property Name
     }
 }

--- a/src/PowerShellGet/public/psgetfunctions/Install-Module.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Install-Module.ps1
@@ -155,6 +155,13 @@ function Install-Module {
                 if ($ev) { return }
             }
 
+            $modules = Find-Module @PSBoundParameters
+            $distinctRepositories = $modules.Repository | Microsoft.PowerShell.Utility\Select-Object -Unique
+            if (([array]$distinctRepositories).Count -gt 1) {
+                $preferredRepository = Get-PSRepository -Name $distinctRepositories | Microsoft.PowerShell.Utility\Select-Object -First 1
+                $PSBoundParameters['Source'] = $preferredRepository.Name
+            }
+
             $null = PackageManagement\Install-Package @PSBoundParameters
         }
         elseif ($PSCmdlet.ParameterSetName -eq "InputObject") {

--- a/src/PowerShellGet/public/psgetfunctions/Install-Module.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Install-Module.ps1
@@ -155,7 +155,14 @@ function Install-Module {
                 if ($ev) { return }
             }
 
-            $modules = Find-Module @PSBoundParameters
+            $findCommand = Get-Command -Name 'Find-Module' -Module 'PowerShellGet'
+            $findSplat = @{ }
+            $findParameters = $PSBoundParameters.Keys | Where-Object { $findCommand.Parameters.Keys -contains $_ }
+            foreach ($findParameter in $findParameters) {
+                $findSplat[$findParameter] = $PSBoundParameters[$findParameter]
+            }
+
+            $modules = Find-Module @findSplat
             $distinctRepositories = $modules.Repository | Microsoft.PowerShell.Utility\Select-Object -Unique
             if (([array]$distinctRepositories).Count -gt 1) {
                 $preferredRepository = Get-PSRepository -Name $distinctRepositories | Microsoft.PowerShell.Utility\Select-Object -First 1


### PR DESCRIPTION
This addresses a portion of issue #340.

* Get-PSRepository now returns trusted repos, then untrusted repos. They are also sorted alphabetically. 
* Install-Module now does a Find-Module based on the parameters and if there are multiple repositories found, the first result is picked and set as the Source parameter for Install-Package. 

Tests were added for both changes. I'm concerned that Find-Module will have a performance impact, but I'm not sure how else to do that check unless it's done at the PackageManagement\Install-Package function instead.