### PR TITLE
Fix for nuget and dotnet error when publishing

### DIFF
--- a/src/PowerShellGet/private/functions/Publish-PSArtifactUtility.ps1
+++ b/src/PowerShellGet/private/functions/Publish-PSArtifactUtility.ps1
@@ -422,7 +422,7 @@ function Publish-PSArtifactUtility {
         if ($DotnetCommandPath) {
             Publish-NugetPackage -NupkgPath $NupkgFullName -Destination $Destination -NugetApiKey $NugetApiKey -UseDotnetCli -Verbose:$VerbosePreference
         }
-        if ($NuGetExePath) {
+        elseif ($NuGetExePath) {
             Publish-NugetPackage -NupkgPath $NupkgFullName -Destination $Destination -NugetApiKey $NugetApiKey -NugetExePath $NuGetExePath -Verbose:$VerbosePreference
         }
 


### PR DESCRIPTION
Only call either dotnet or nuget when publishing- fix for part of #433