### PR TITLE
Not all functions with a Path parameter have a LiteralPath parameter #488

### DIFF
--- a/src/PowerShellGet/public/psgetfunctions/New-ScriptFileInfo.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/New-ScriptFileInfo.ps1
@@ -1,24 +1,21 @@
-function New-ScriptFileInfo
-{
+function New-ScriptFileInfo {
     <#
     .ExternalHelp PSModule-help.xml
     #>
-    [CmdletBinding(PositionalBinding=$false,
-                   SupportsShouldProcess=$true,
-                   HelpUri='https://go.microsoft.com/fwlink/?LinkId=619792')]
+    [CmdletBinding(PositionalBinding = $false,
+        SupportsShouldProcess = $true,
+        HelpUri = 'https://go.microsoft.com/fwlink/?LinkId=619792')]
     Param
     (
         [Parameter(Mandatory = $false,
-            Position=0,
-            ValueFromPipelineByPropertyName = $true,
-            ParameterSetName = "PathParameterSet")]
+            Position = 0,
+            ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $Path,
 
         [Parameter(Mandatory = $false,
-            ValueFromPipelineByPropertyName = $true,
-            ParameterSetName = "LiteralPathParameterSet")]
+            ValueFromPipelineByPropertyName = $true)]
         [Alias('PSPath')]
         [ValidateNotNullOrEmpty()]
         [string]
@@ -34,7 +31,7 @@ function New-ScriptFileInfo
         [string]
         $Author,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $Description,
@@ -98,8 +95,8 @@ function New-ScriptFileInfo
         [string[]]
         $ReleaseNotes,
 
-		[Parameter()]
-		[ValidateNotNullOrEmpty()]
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [string]
         $PrivateData,
 
@@ -112,106 +109,97 @@ function New-ScriptFileInfo
         $Force
     )
 
-    Process
-    {
-        # If $Path is null, use the value of $literalpath
-        if (!$Path)
-        {
-            $Path = $LiteralPath;
+    Process {
+        if ($Path) {
+            #echo "Path is not null, Do nothing"
+        }
+        Elseif ($LiteralPath) {
+            #echo "LiteralPath is not null, assign the value to Path"
+            $Path = $LiteralPath
+        }
+        else {
+            #echo "Both are null, do nothing"
         }
 
-        if($Path)
-        {
-            if(-not $Path.EndsWith('.ps1', [System.StringComparison]::OrdinalIgnoreCase))
-            {
+        if ($Path) {
+            if (-not $Path.EndsWith('.ps1', [System.StringComparison]::OrdinalIgnoreCase)) {
                 $errorMessage = ($LocalizedData.InvalidScriptFilePath -f $Path)
                 ThrowError  -ExceptionName 'System.ArgumentException' `
-                            -ExceptionMessage $errorMessage `
-                            -ErrorId 'InvalidScriptFilePath' `
-                            -CallerPSCmdlet $PSCmdlet `
-                            -ExceptionObject $Path `
-                            -ErrorCategory InvalidArgument
+                    -ExceptionMessage $errorMessage `
+                    -ErrorId 'InvalidScriptFilePath' `
+                    -CallerPSCmdlet $PSCmdlet `
+                    -ExceptionObject $Path `
+                    -ErrorCategory InvalidArgument
                 return
             }
 
-            if(-not $Force -and (Microsoft.PowerShell.Management\Test-Path -Path $Path))
-            {
+            if (-not $Force -and (Microsoft.PowerShell.Management\Test-Path -Path $Path)) {
                 $errorMessage = ($LocalizedData.ScriptFileExist -f $Path)
                 ThrowError  -ExceptionName 'System.ArgumentException' `
-                            -ExceptionMessage $errorMessage `
-                            -ErrorId 'ScriptFileExist' `
-                            -CallerPSCmdlet $PSCmdlet `
-                            -ExceptionObject $Path `
-                            -ErrorCategory InvalidArgument
+                    -ExceptionMessage $errorMessage `
+                    -ErrorId 'ScriptFileExist' `
+                    -CallerPSCmdlet $PSCmdlet `
+                    -ExceptionObject $Path `
+                    -ErrorCategory InvalidArgument
                 return
             }
         }
-        elseif(-not $PassThru)
-        {
+        elseif (-not $PassThru) {
             ThrowError  -ExceptionName 'System.ArgumentException' `
-                        -ExceptionMessage $LocalizedData.MissingTheRequiredPathOrPassThruParameter `
-                        -ErrorId 'MissingTheRequiredPathOrPassThruParameter' `
-                        -CallerPSCmdlet $PSCmdlet `
-                        -ErrorCategory InvalidArgument
+                -ExceptionMessage $LocalizedData.MissingTheRequiredPathOrPassThruParameter `
+                -ErrorId 'MissingTheRequiredPathOrPassThruParameter' `
+                -CallerPSCmdlet $PSCmdlet `
+                -ErrorCategory InvalidArgument
             return
         }
 
-        if(-not $Version)
-        {
+        if (-not $Version) {
             $Version = '1.0'
         }
-        else
-        {
+        else {
             $result = ValidateAndGet-VersionPrereleaseStrings -Version $Version -CallerPSCmdlet $PSCmdlet
-            if (-not $result)
-            {
+            if (-not $result) {
                 # ValidateAndGet-VersionPrereleaseStrings throws the error.
                 # returning to avoid further execution when different values are specified for -ErrorAction parameter
                 return
             }
         }
 
-        if(-not $Author)
-        {
-            if($script:IsWindows)
-            {
+        if (-not $Author) {
+            if ($script:IsWindows) {
                 $Author = (Get-EnvironmentVariable -Name 'USERNAME' -Target $script:EnvironmentVariableTarget.Process -ErrorAction SilentlyContinue)
             }
-            else
-            {
+            else {
                 $Author = $env:USER
             }
         }
 
-        if(-not $Guid)
-        {
+        if (-not $Guid) {
             $Guid = [System.Guid]::NewGuid()
         }
 
         $params = @{
-            Version = $Version
-            Author = $Author
-            Guid = $Guid
-            CompanyName = $CompanyName
-            Copyright = $Copyright
+            Version                    = $Version
+            Author                     = $Author
+            Guid                       = $Guid
+            CompanyName                = $CompanyName
+            Copyright                  = $Copyright
             ExternalModuleDependencies = $ExternalModuleDependencies
-            RequiredScripts = $RequiredScripts
+            RequiredScripts            = $RequiredScripts
             ExternalScriptDependencies = $ExternalScriptDependencies
-            Tags = $Tags
-            ProjectUri = $ProjectUri
-            LicenseUri = $LicenseUri
-            IconUri = $IconUri
-            ReleaseNotes = $ReleaseNotes
-			PrivateData = $PrivateData
+            Tags                       = $Tags
+            ProjectUri                 = $ProjectUri
+            LicenseUri                 = $LicenseUri
+            IconUri                    = $IconUri
+            ReleaseNotes               = $ReleaseNotes
+            PrivateData                = $PrivateData
         }
 
-        if(-not (Validate-ScriptFileInfoParameters -parameters $params))
-        {
+        if (-not (Validate-ScriptFileInfoParameters -parameters $params)) {
             return
         }
 
-        if("$Description" -match '<#' -or "$Description" -match '#>')
-        {
+        if ("$Description" -match '<#' -or "$Description" -match '#>') {
             $message = $LocalizedData.InvalidParameterValue -f ($Description, 'Description')
             Write-Error -Message $message -ErrorId 'InvalidParameterValue' -Category InvalidArgument
 
@@ -227,8 +215,7 @@ function New-ScriptFileInfo
         $ScriptMetadataString = $PSScriptInfoString
         $ScriptMetadataString += "`r`n"
 
-        if("$requiresStrings".Trim())
-        {
+        if ("$requiresStrings".Trim()) {
             $ScriptMetadataString += "`r`n"
             $ScriptMetadataString += $requiresStrings -join "`r`n"
             $ScriptMetadataString += "`r`n"
@@ -240,30 +227,25 @@ function New-ScriptFileInfo
 
         $tempScriptFilePath = Microsoft.PowerShell.Management\Join-Path -Path $script:TempPath -ChildPath "$(Get-Random).ps1"
 
-        try
-        {
+        try {
             Microsoft.PowerShell.Management\Set-Content -Value $ScriptMetadataString -Path $tempScriptFilePath -Force -WhatIf:$false -Confirm:$false
 
             $scriptInfo = Test-ScriptFileInfo -Path $tempScriptFilePath
 
-            if(-not $scriptInfo)
-            {
+            if (-not $scriptInfo) {
                 # Above Test-ScriptFileInfo cmdlet writes the errors
                 return
             }
 
-    	    if($Path -and ($Force -or $PSCmdlet.ShouldProcess($Path, ($LocalizedData.NewScriptFileInfowhatIfMessage -f $Path) )))
-    	    {
+            if ($Path -and ($Force -or $PSCmdlet.ShouldProcess($Path, ($LocalizedData.NewScriptFileInfowhatIfMessage -f $Path) ))) {
                 Microsoft.PowerShell.Management\Copy-Item -Path $tempScriptFilePath -Destination $Path -Force -WhatIf:$false -Confirm:$false
             }
 
-            if($PassThru)
-            {
+            if ($PassThru) {
                 Write-Output -InputObject $ScriptMetadataString
             }
         }
-        finally
-        {
+        finally {
             Microsoft.PowerShell.Management\Remove-Item -Path $tempScriptFilePath -Force -WhatIf:$false -Confirm:$false -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
         }
     }

--- a/src/PowerShellGet/public/psgetfunctions/New-ScriptFileInfo.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/New-ScriptFileInfo.ps1
@@ -3,14 +3,12 @@ function New-ScriptFileInfo {
     .ExternalHelp PSModule-help.xml
     #>
     [CmdletBinding(PositionalBinding = $false,
-        DefaultParameterSetName = 'PathParameterSet',
         SupportsShouldProcess = $true,
         HelpUri = 'https://go.microsoft.com/fwlink/?LinkId=619792')]
     Param
     (
         [Parameter(Mandatory = $false,
             Position = 0,
-            ParameterSetName = 'PathParameterSet',
             ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]
         [string]
@@ -18,7 +16,6 @@ function New-ScriptFileInfo {
 
         [Parameter(Mandatory = $false,
             Position = 0,
-            ParameterSetName = 'LiteralPathParameterSet',
             ValueFromPipelineByPropertyName = $true)]
         [Alias('PSPath')]
         [ValidateNotNullOrEmpty()]

--- a/src/PowerShellGet/public/psgetfunctions/New-ScriptFileInfo.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/New-ScriptFileInfo.ps1
@@ -14,13 +14,6 @@ function New-ScriptFileInfo {
         [string]
         $Path,
 
-        [Parameter(Mandatory = $false,
-            ValueFromPipelineByPropertyName = $true)]
-        [Alias('PSPath')]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $LiteralPath,
-
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [string]
@@ -110,17 +103,6 @@ function New-ScriptFileInfo {
     )
 
     Process {
-        if ($Path) {
-            #echo "Path is not null, Do nothing"
-        }
-        Elseif ($LiteralPath) {
-            #echo "LiteralPath is not null, assign the value to Path"
-            $Path = $LiteralPath
-        }
-        else {
-            #echo "Both are null, do nothing"
-        }
-
         if ($Path) {
             if (-not $Path.EndsWith('.ps1', [System.StringComparison]::OrdinalIgnoreCase)) {
                 $errorMessage = ($LocalizedData.InvalidScriptFilePath -f $Path)

--- a/src/PowerShellGet/public/psgetfunctions/New-ScriptFileInfo.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/New-ScriptFileInfo.ps1
@@ -3,16 +3,27 @@ function New-ScriptFileInfo {
     .ExternalHelp PSModule-help.xml
     #>
     [CmdletBinding(PositionalBinding = $false,
+        DefaultParameterSetName = 'PathParameterSet',
         SupportsShouldProcess = $true,
         HelpUri = 'https://go.microsoft.com/fwlink/?LinkId=619792')]
     Param
     (
         [Parameter(Mandatory = $false,
             Position = 0,
+            ParameterSetName = 'PathParameterSet',
             ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $Path,
+
+        [Parameter(Mandatory = $false,
+            Position = 0,
+            ParameterSetName = 'LiteralPathParameterSet',
+            ValueFromPipelineByPropertyName = $true)]
+        [Alias('PSPath')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $LiteralPath,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -103,6 +114,20 @@ function New-ScriptFileInfo {
     )
 
     Process {
+        if ($Path) {
+            if (!$Path) {
+                #echo "Path is not null, Do nothing"
+                $Path = $LiteralPath;
+            }
+        }
+        Elseif ($LiteralPath) {
+            #echo "LiteralPath is not null, assign the value to Path"
+            $Path = $LiteralPath
+        }
+        else {
+            #echo "Both are null, do nothing"
+        }
+
         if ($Path) {
             if (-not $Path.EndsWith('.ps1', [System.StringComparison]::OrdinalIgnoreCase)) {
                 $errorMessage = ($LocalizedData.InvalidScriptFilePath -f $Path)

--- a/src/PowerShellGet/public/psgetfunctions/New-ScriptFileInfo.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/New-ScriptFileInfo.ps1
@@ -8,12 +8,21 @@ function New-ScriptFileInfo
                    HelpUri='https://go.microsoft.com/fwlink/?LinkId=619792')]
     Param
     (
-        [Parameter(Mandatory=$false,
-                   Position=0,
-                   ValueFromPipelineByPropertyName=$true)]
+        [Parameter(Mandatory = $false,
+            Position=0,
+            ValueFromPipelineByPropertyName = $true,
+            ParameterSetName = "PathParameterSet")]
         [ValidateNotNullOrEmpty()]
         [string]
         $Path,
+
+        [Parameter(Mandatory = $false,
+            ValueFromPipelineByPropertyName = $true,
+            ParameterSetName = "LiteralPathParameterSet")]
+        [Alias('PSPath')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $LiteralPath,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -105,6 +114,12 @@ function New-ScriptFileInfo
 
     Process
     {
+        # If $Path is null, use the value of $literalpath
+        if (!$Path)
+        {
+            $Path = $LiteralPath;
+        }
+
         if($Path)
         {
             if(-not $Path.EndsWith('.ps1', [System.StringComparison]::OrdinalIgnoreCase))

--- a/src/PowerShellGet/public/psgetfunctions/Publish-Module.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Publish-Module.ps1
@@ -15,15 +15,13 @@ function Publish-Module {
         [string]
         $Name,
 
-        [Parameter(Mandatory = $true,
-            ParameterSetName = "ModulePathParameterSet",
+        [Parameter(Mandatory = $false,
             ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $Path,
 
-        [Parameter(Mandatory = $true,
-            ParameterSetName = "ModuleLiteralPathParameterSet",
+        [Parameter(Mandatory = $false,
             ValueFromPipelineByPropertyName = $true)]
         [Alias('PSPath')]
         [ValidateNotNullOrEmpty()]
@@ -131,12 +129,17 @@ function Publish-Module {
     }
 
     Process {
-        # If $Path is null, use the value of $literalpath
-        if (!$Path)
-        {
-            $Path = $LiteralPath;
+        if ($Path) {
+            #echo "Path is not null, Do nothing"
         }
-        
+        Elseif ($LiteralPath) {
+            #echo "LiteralPath is not null, assign the value to Path"
+            $Path = $LiteralPath
+        }
+        else {
+            #echo "Both are null, do nothing"
+        }
+
         if ($Repository -eq $Script:PSGalleryModuleSource) {
             $moduleSource = Get-PSRepository -Name $Repository -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
             if (-not $moduleSource) {
@@ -229,16 +232,16 @@ function Publish-Module {
             # Find the module to be published locally, search by name and RequiredVersion
             $module = Microsoft.PowerShell.Core\Get-Module -ListAvailable -Name $Name -Verbose:$false |
                 Microsoft.PowerShell.Core\Where-Object {
-                $modInfoPrerelease = $null
-                if ($_.PrivateData -and
-                    $_.PrivateData.GetType().ToString() -eq "System.Collections.Hashtable" -and
-                    $_.PrivateData["PSData"] -and
-                    $_.PrivateData.PSData.GetType().ToString() -eq "System.Collections.Hashtable" -and
-                    $_.PrivateData.PSData["Prerelease"]) {
-                    $modInfoPrerelease = $_.PrivateData.PSData.Prerelease
+                    $modInfoPrerelease = $null
+                    if ($_.PrivateData -and
+                        $_.PrivateData.GetType().ToString() -eq "System.Collections.Hashtable" -and
+                        $_.PrivateData["PSData"] -and
+                        $_.PrivateData.PSData.GetType().ToString() -eq "System.Collections.Hashtable" -and
+                        $_.PrivateData.PSData["Prerelease"]) {
+                        $modInfoPrerelease = $_.PrivateData.PSData.Prerelease
+                    }
+                    (-not $RequiredVersion) -or ( ($reqVersion -eq $_.Version) -and ($reqPrerelease -match $modInfoPrerelease) )
                 }
-                (-not $RequiredVersion) -or ( ($reqVersion -eq $_.Version) -and ($reqPrerelease -match $modInfoPrerelease) )
-            }
 
             if (-not $module) {
                 if ($RequiredVersion) {
@@ -392,13 +395,13 @@ function Publish-Module {
         # This finds all the items without force (leaving out hidden files and dirs) then copies them
         Microsoft.PowerShell.Management\Get-ChildItem $Path -recurse |
             Microsoft.PowerShell.Management\Copy-Item -Force -Confirm:$false -WhatIf:$false -Destination {
-            if ($_.PSIsContainer) {
-                Join-Path $tempModulePathForFormatVersion $_.Parent.FullName.substring($path.length)
+                if ($_.PSIsContainer) {
+                    Join-Path $tempModulePathForFormatVersion $_.Parent.FullName.substring($path.length)
+                }
+                else {
+                    join-path $tempModulePathForFormatVersion $_.FullName.Substring($path.Length)
+                }
             }
-            else {
-                join-path $tempModulePathForFormatVersion $_.FullName.Substring($path.Length)
-            }
-        }
 
         try {
             $manifestPath = Join-PathUtility -Path $tempModulePathForFormatVersion -ChildPath "$moduleName.psd1" -PathType File
@@ -472,7 +475,7 @@ function Publish-Module {
             # Check if the specified module name is already used for a script on the specified repository
             # Use Find-Script to check if that name is already used as scriptname
             $scriptPSGetItemInfo = Find-Script @FindParameters |
-                Microsoft.PowerShell.Core\Where-Object {$_.Name -eq $moduleName} |
+                Microsoft.PowerShell.Core\Where-Object { $_.Name -eq $moduleName } |
                 Microsoft.PowerShell.Utility\Select-Object -Last 1 -ErrorAction Ignore
             if ($scriptPSGetItemInfo) {
                 $message = $LocalizedData.SpecifiedNameIsAlearyUsed -f ($moduleName, $Repository, 'Find-Script')
@@ -486,7 +489,7 @@ function Publish-Module {
 
             $null = $FindParameters.Remove('Tag')
             $currentPSGetItemInfo = Find-Module @FindParameters |
-                Microsoft.PowerShell.Core\Where-Object {$_.Name -eq $moduleInfo.Name} |
+                Microsoft.PowerShell.Core\Where-Object { $_.Name -eq $moduleInfo.Name } |
                 Microsoft.PowerShell.Utility\Select-Object -Last 1 -ErrorAction Ignore
 
             if ($currentPSGetItemInfo) {

--- a/src/PowerShellGet/public/psgetfunctions/Publish-Module.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Publish-Module.ps1
@@ -22,6 +22,14 @@ function Publish-Module {
         [string]
         $Path,
 
+        [Parameter(Mandatory = $true,
+            ParameterSetName = "ModuleLiteralPathParameterSet",
+            ValueFromPipelineByPropertyName = $true)]
+        [Alias('PSPath')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $LiteralPath,
+
         [Parameter(ParameterSetName = "ModuleNameParameterSet")]
         [ValidateNotNullOrEmpty()]
         [string]
@@ -123,6 +131,12 @@ function Publish-Module {
     }
 
     Process {
+        # If $Path is null, use the value of $literalpath
+        if (!$Path)
+        {
+            $Path = $LiteralPath;
+        }
+        
         if ($Repository -eq $Script:PSGalleryModuleSource) {
             $moduleSource = Get-PSRepository -Name $Repository -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
             if (-not $moduleSource) {

--- a/src/PowerShellGet/public/psgetfunctions/Publish-Module.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Publish-Module.ps1
@@ -15,18 +15,12 @@ function Publish-Module {
         [string]
         $Name,
 
-        [Parameter(Mandatory = $false,
+        [Parameter(Mandatory = $true,
+            ParameterSetName = "ModulePathParameterSet",
             ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $Path,
-
-        [Parameter(Mandatory = $false,
-            ValueFromPipelineByPropertyName = $true)]
-        [Alias('PSPath')]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $LiteralPath,
 
         [Parameter(ParameterSetName = "ModuleNameParameterSet")]
         [ValidateNotNullOrEmpty()]
@@ -129,17 +123,6 @@ function Publish-Module {
     }
 
     Process {
-        if ($Path) {
-            #echo "Path is not null, Do nothing"
-        }
-        Elseif ($LiteralPath) {
-            #echo "LiteralPath is not null, assign the value to Path"
-            $Path = $LiteralPath
-        }
-        else {
-            #echo "Both are null, do nothing"
-        }
-
         if ($Repository -eq $Script:PSGalleryModuleSource) {
             $moduleSource = Get-PSRepository -Name $Repository -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
             if (-not $moduleSource) {

--- a/src/PowerShellGet/public/psgetfunctions/Publish-Module.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Publish-Module.ps1
@@ -22,6 +22,14 @@ function Publish-Module {
         [string]
         $Path,
 
+        [Parameter(Mandatory = $true,
+            ParameterSetName = "ModuleLiteralPathParameterSet",
+            ValueFromPipelineByPropertyName = $true)]
+        [Alias('PSPath')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $LiteralPath,
+
         [Parameter(ParameterSetName = "ModuleNameParameterSet")]
         [ValidateNotNullOrEmpty()]
         [string]
@@ -123,6 +131,21 @@ function Publish-Module {
     }
 
     Process {
+
+        if ($Path) {
+            if (!$Path) {
+                #echo "Path is not null, Do nothing"
+                $Path = $LiteralPath;
+            }
+        }
+        Elseif ($LiteralPath) {
+            #echo "LiteralPath is not null, assign the value to Path"
+            $Path = $LiteralPath
+        }
+        else {
+            #echo "Both are null, do nothing"
+        }
+
         if ($Repository -eq $Script:PSGalleryModuleSource) {
             $moduleSource = Get-PSRepository -Name $Repository -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
             if (-not $moduleSource) {

--- a/src/PowerShellGet/public/psgetfunctions/Update-ModuleManifest.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Update-ModuleManifest.ps1
@@ -3,16 +3,27 @@ function Update-ModuleManifest {
     .ExternalHelp PSModule-help.xml
     #>
     [CmdletBinding(SupportsShouldProcess = $true,
+        DefaultParameterSetName = 'PathParameterSet',
         PositionalBinding = $false,
         HelpUri = 'https://go.microsoft.com/fwlink/?LinkId=619311')]
     Param
     (
         [Parameter(Mandatory = $true,
             Position = 0,
+            ParameterSetName = 'PathParameterSet',
             ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $Path,
+
+        [Parameter(Mandatory = $true,
+            Position = 0,
+            ParameterSetName = 'LiteralPathParameterSet',
+            ValueFromPipelineByPropertyName = $true)]
+        [Alias('PSPath')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $LiteralPath,
 
         [ValidateNotNullOrEmpty()]
         [Object[]]
@@ -207,6 +218,20 @@ function Update-ModuleManifest {
 
 
     )
+
+    if ($Path) {
+        if (!$Path) {
+            #echo "Path is not null, Do nothing"
+            $Path = $LiteralPath;
+        }
+    }
+    Elseif ($LiteralPath) {
+        #echo "LiteralPath is not null, assign the value to Path"
+        $Path = $LiteralPath
+    }
+    else {
+        #echo "Both are null, do nothing"
+    }
 
     if (-not (Microsoft.PowerShell.Management\Test-Path -Path $Path -PathType Leaf)) {
         $message = $LocalizedData.UpdateModuleManifestPathCannotFound -f ($Path)

--- a/src/PowerShellGet/public/psgetfunctions/Update-ModuleManifest.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Update-ModuleManifest.ps1
@@ -3,17 +3,25 @@ function Update-ModuleManifest
     <#
     .ExternalHelp PSModule-help.xml
     #>
-    [CmdletBinding(SupportsShouldProcess=$true,
-                   PositionalBinding=$false,
-                   HelpUri='https://go.microsoft.com/fwlink/?LinkId=619311')]
+    [CmdletBinding(SupportsShouldProcess = $true,
+        PositionalBinding = $false,
+        HelpUri = 'https://go.microsoft.com/fwlink/?LinkId=619311')]
     Param
     (
-        [Parameter(Mandatory=$true,
-                   Position=0,
-                   ValueFromPipelineByPropertyName=$true)]
+        [Parameter(Mandatory = $true,
+            ValueFromPipelineByPropertyName = $true,
+            ParameterSetName = "NameAndPathParameterSet")]
         [ValidateNotNullOrEmpty()]
         [string]
         $Path,
+
+        [Parameter(Mandatory = $true,
+            ValueFromPipelineByPropertyName = $true,
+            ParameterSetName = "NameAndLiteralPathParameterSet")]
+        [ValidateNotNullOrEmpty()]
+        [Alias('PSPath')]
+        [string]
+        $LiteralPath,
 
         [ValidateNotNullOrEmpty()]
         [Object[]]
@@ -59,7 +67,7 @@ function Update-ModuleManifest
         $ProcessorArchitecture,
 
         [Parameter()]
-        [ValidateSet('Desktop','Core')]
+        [ValidateSet('Desktop', 'Core')]
         [string[]]
         $CompatiblePSEditions,
 
@@ -209,532 +217,441 @@ function Update-ModuleManifest
 
     )
 
-    if(-not (Microsoft.PowerShell.Management\Test-Path -Path $Path -PathType Leaf))
+    # If $Path is null, use the value of $literalpath
+    if (!$Path)
     {
+        $Path = $LiteralPath;
+    }
+       
+    if (-not (Microsoft.PowerShell.Management\Test-Path -Path $Path -PathType Leaf)) {
         $message = $LocalizedData.UpdateModuleManifestPathCannotFound -f ($Path)
         ThrowError -ExceptionName "System.ArgumentException" `
-                   -ExceptionMessage $message `
-                   -ErrorId "InvalidModuleManifestFilePath" `
-                   -ExceptionObject $Path `
-                   -CallerPSCmdlet $PSCmdlet `
-                   -ErrorCategory InvalidArgument
+            -ExceptionMessage $message `
+            -ErrorId "InvalidModuleManifestFilePath" `
+            -ExceptionObject $Path `
+            -CallerPSCmdlet $PSCmdlet `
+            -ErrorCategory InvalidArgument
     }
 
     $ModuleManifestHashTable = $null
 
-    try
-    {
+    try {
         $ModuleManifestHashTable = Get-ManifestHashTable -Path $Path -CallerPSCmdlet $PSCmdlet
     }
-    catch
-    {
+    catch {
         $message = $LocalizedData.TestModuleManifestFail -f ($_.Exception.Message)
         ThrowError -ExceptionName "System.ArgumentException" `
-                    -ExceptionMessage $message `
-                    -ErrorId "InvalidModuleManifestFile" `
-                    -ExceptionObject $Path `
-                    -CallerPSCmdlet $PSCmdlet `
-                    -ErrorCategory InvalidArgument
+            -ExceptionMessage $message `
+            -ErrorId "InvalidModuleManifestFile" `
+            -ExceptionObject $Path `
+            -CallerPSCmdlet $PSCmdlet `
+            -ErrorCategory InvalidArgument
         return
     }
 
     #Get the original module manifest and migrate all the fields to the new module manifest, including the specified parameter values
     $moduleInfo = $null
 
-    try
-    {
+    try {
         $moduleInfo = Microsoft.PowerShell.Core\Test-ModuleManifest -Path $Path -ErrorAction Stop
     }
-    catch
-    {
+    catch {
         # Throw an error only if Test-ModuleManifest did not return the PSModuleInfo object.
         # This enables the users to use Update-ModuleManifest cmdlet to update the metadata.
-        if(-not $moduleInfo)
-        {
+        if (-not $moduleInfo) {
             $message = $LocalizedData.TestModuleManifestFail -f ($_.Exception.Message)
             ThrowError -ExceptionName "System.ArgumentException" `
-                       -ExceptionMessage $message `
-                       -ErrorId "InvalidModuleManifestFile" `
-                       -ExceptionObject $Path `
-                       -CallerPSCmdlet $PSCmdlet `
-                       -ErrorCategory InvalidArgument
+                -ExceptionMessage $message `
+                -ErrorId "InvalidModuleManifestFile" `
+                -ExceptionObject $Path `
+                -CallerPSCmdlet $PSCmdlet `
+                -ErrorCategory InvalidArgument
             return
         }
     }
 
     #Params to pass to New-ModuleManifest module
-    $params = @{}
+    $params = @{ }
 
     #NestedModules is read-only property
-    if($NestedModules)
-    {
-        $params.Add("NestedModules",$NestedModules)
+    if ($NestedModules) {
+        $params.Add("NestedModules", $NestedModules)
     }
-    elseif($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("NestedModules"))
-    {
-        $params.Add("NestedModules",$ModuleManifestHashtable.NestedModules)
+    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("NestedModules")) {
+        $params.Add("NestedModules", $ModuleManifestHashtable.NestedModules)
     }
 
     #Guid is read-only property
-    if($Guid)
-    {
-        $params.Add("Guid",$Guid)
+    if ($Guid) {
+        $params.Add("Guid", $Guid)
     }
-    elseif($moduleInfo.Guid)
-    {
-        $params.Add("Guid",$moduleInfo.Guid)
+    elseif ($moduleInfo.Guid) {
+        $params.Add("Guid", $moduleInfo.Guid)
     }
 
-    if($Author)
-    {
-        $params.Add("Author",$Author)
+    if ($Author) {
+        $params.Add("Author", $Author)
     }
-    elseif($moduleInfo.Author)
-    {
-        $params.Add("Author",$moduleInfo.Author)
+    elseif ($moduleInfo.Author) {
+        $params.Add("Author", $moduleInfo.Author)
     }
 
-    if($CompanyName)
-    {
-        $params.Add("CompanyName",$CompanyName)
+    if ($CompanyName) {
+        $params.Add("CompanyName", $CompanyName)
     }
-    elseif($moduleInfo.CompanyName)
-    {
-        $params.Add("CompanyName",$moduleInfo.CompanyName)
-    } 
-    else  
-    {
+    elseif ($moduleInfo.CompanyName) {
+        $params.Add("CompanyName", $moduleInfo.CompanyName)
+    }
+    else {
         #Creating a unique disposable company name to later be replaced by ''
         #Work-around to deal with New-ModuleManifest changing '' to 'Unknown'
         $params.Add("CompanyName", '__UPDATEDCOMPANYNAMETOBEREPLACEDINFUNCTION__')
     }
 
-    if($Copyright)
-    {
-        $params.Add("CopyRight",$Copyright)
+    if ($Copyright) {
+        $params.Add("CopyRight", $Copyright)
     }
-    elseif($moduleInfo.Copyright)
-    {
-        $params.Add("Copyright",$moduleInfo.Copyright)
+    elseif ($moduleInfo.Copyright) {
+        $params.Add("Copyright", $moduleInfo.Copyright)
     }
 
-    if($RootModule)
-    {
-        $params.Add("RootModule",$RootModule)
+    if ($RootModule) {
+        $params.Add("RootModule", $RootModule)
     }
-    elseif($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("RootModule") -and $moduleInfo.RootModule)
-    {
-        $params.Add("RootModule",$ModuleManifestHashTable.RootModule)
+    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("RootModule") -and $moduleInfo.RootModule) {
+        $params.Add("RootModule", $ModuleManifestHashTable.RootModule)
     }
 
-    if($ModuleVersion)
-    {
-        $params.Add("ModuleVersion",$ModuleVersion)
+    if ($ModuleVersion) {
+        $params.Add("ModuleVersion", $ModuleVersion)
     }
-    elseif($moduleInfo.Version)
-    {
-        $params.Add("ModuleVersion",$moduleInfo.Version)
+    elseif ($moduleInfo.Version) {
+        $params.Add("ModuleVersion", $moduleInfo.Version)
     }
 
-    if($Description)
-    {
-        $params.Add("Description",$Description)
+    if ($Description) {
+        $params.Add("Description", $Description)
     }
-    elseif($moduleInfo.Description)
-    {
-        $params.Add("Description",$moduleInfo.Description)
+    elseif ($moduleInfo.Description) {
+        $params.Add("Description", $moduleInfo.Description)
     }
 
-    if($ProcessorArchitecture)
-    {
-        $params.Add("ProcessorArchitecture",$ProcessorArchitecture)
+    if ($ProcessorArchitecture) {
+        $params.Add("ProcessorArchitecture", $ProcessorArchitecture)
     }
     #Check if ProcessorArchitecture has a value and is not 'None' on lower version PS
-    elseif($moduleInfo.ProcessorArchitecture -and $moduleInfo.ProcessorArchitecture -ne 'None')
-    {
-        $params.Add("ProcessorArchitecture",$moduleInfo.ProcessorArchitecture)
+    elseif ($moduleInfo.ProcessorArchitecture -and $moduleInfo.ProcessorArchitecture -ne 'None') {
+        $params.Add("ProcessorArchitecture", $moduleInfo.ProcessorArchitecture)
     }
 
-    if($PowerShellVersion)
-    {
-        $params.Add("PowerShellVersion",$PowerShellVersion)
+    if ($PowerShellVersion) {
+        $params.Add("PowerShellVersion", $PowerShellVersion)
     }
-    elseif($moduleinfo.PowerShellVersion)
-    {
-        $params.Add("PowerShellVersion",$moduleinfo.PowerShellVersion)
+    elseif ($moduleinfo.PowerShellVersion) {
+        $params.Add("PowerShellVersion", $moduleinfo.PowerShellVersion)
     }
 
-    if($ClrVersion)
-    {
-        $params.Add("ClrVersion",$ClrVersion)
+    if ($ClrVersion) {
+        $params.Add("ClrVersion", $ClrVersion)
     }
-    elseif($moduleInfo.ClrVersion)
-    {
-        $params.Add("ClrVersion",$moduleInfo.ClrVersion)
+    elseif ($moduleInfo.ClrVersion) {
+        $params.Add("ClrVersion", $moduleInfo.ClrVersion)
     }
 
-    if($DotNetFrameworkVersion)
-    {
-        $params.Add("DotNetFrameworkVersion",$DotNetFrameworkVersion)
+    if ($DotNetFrameworkVersion) {
+        $params.Add("DotNetFrameworkVersion", $DotNetFrameworkVersion)
     }
-    elseif($moduleInfo.DotNetFrameworkVersion)
-    {
-        $params.Add("DotNetFrameworkVersion",$moduleInfo.DotNetFrameworkVersion)
+    elseif ($moduleInfo.DotNetFrameworkVersion) {
+        $params.Add("DotNetFrameworkVersion", $moduleInfo.DotNetFrameworkVersion)
     }
 
-    if($PowerShellHostName)
-    {
-        $params.Add("PowerShellHostName",$PowerShellHostName)
+    if ($PowerShellHostName) {
+        $params.Add("PowerShellHostName", $PowerShellHostName)
     }
-    elseif($moduleInfo.PowerShellHostName)
-    {
-        $params.Add("PowerShellHostName",$moduleInfo.PowerShellHostName)
+    elseif ($moduleInfo.PowerShellHostName) {
+        $params.Add("PowerShellHostName", $moduleInfo.PowerShellHostName)
     }
 
-    if($PowerShellHostVersion)
-    {
-        $params.Add("PowerShellHostVersion",$PowerShellHostVersion)
+    if ($PowerShellHostVersion) {
+        $params.Add("PowerShellHostVersion", $PowerShellHostVersion)
     }
-    elseif($moduleInfo.PowerShellHostVersion)
-    {
-        $params.Add("PowerShellHostVersion",$moduleInfo.PowerShellHostVersion)
+    elseif ($moduleInfo.PowerShellHostVersion) {
+        $params.Add("PowerShellHostVersion", $moduleInfo.PowerShellHostVersion)
     }
 
-    if($RequiredModules)
-    {
-        $params.Add("RequiredModules",$RequiredModules)
+    if ($RequiredModules) {
+        $params.Add("RequiredModules", $RequiredModules)
     }
-    elseif($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("RequiredModules") -and $moduleInfo.RequiredModules)
-    {
-        $params.Add("RequiredModules",$ModuleManifestHashtable.RequiredModules)
+    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("RequiredModules") -and $moduleInfo.RequiredModules) {
+        $params.Add("RequiredModules", $ModuleManifestHashtable.RequiredModules)
     }
 
-    if($TypesToProcess)
-    {
-        $params.Add("TypesToProcess",$TypesToProcess)
+    if ($TypesToProcess) {
+        $params.Add("TypesToProcess", $TypesToProcess)
     }
-    elseif($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("TypesToProcess") -and $moduleInfo.ExportedTypeFiles)
-    {
-        $params.Add("TypesToProcess",$ModuleManifestHashTable.TypesToProcess)
+    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("TypesToProcess") -and $moduleInfo.ExportedTypeFiles) {
+        $params.Add("TypesToProcess", $ModuleManifestHashTable.TypesToProcess)
     }
 
-    if($FormatsToProcess)
-    {
-        $params.Add("FormatsToProcess",$FormatsToProcess)
+    if ($FormatsToProcess) {
+        $params.Add("FormatsToProcess", $FormatsToProcess)
     }
-    elseif($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("FormatsToProcess") -and $moduleInfo.ExportedFormatFiles)
-    {
-        $params.Add("FormatsToProcess",$ModuleManifestHashTable.FormatsToProcess)
+    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("FormatsToProcess") -and $moduleInfo.ExportedFormatFiles) {
+        $params.Add("FormatsToProcess", $ModuleManifestHashTable.FormatsToProcess)
     }
 
-    if($ScriptsToProcess)
-    {
-        $params.Add("ScriptsToProcess",$ScriptstoProcess)
+    if ($ScriptsToProcess) {
+        $params.Add("ScriptsToProcess", $ScriptstoProcess)
     }
-    elseif($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("ScriptsToProcess") -and $moduleInfo.Scripts)
-    {
-        $params.Add("ScriptsToProcess",$ModuleManifestHashTable.ScriptsToProcess)
+    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("ScriptsToProcess") -and $moduleInfo.Scripts) {
+        $params.Add("ScriptsToProcess", $ModuleManifestHashTable.ScriptsToProcess)
     }
 
-    if($RequiredAssemblies)
-    {
-        $params.Add("RequiredAssemblies",$RequiredAssemblies)
+    if ($RequiredAssemblies) {
+        $params.Add("RequiredAssemblies", $RequiredAssemblies)
     }
-    elseif($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("RequiredAssemblies") -and $moduleInfo.RequiredAssemblies)
-    {
-        $params.Add("RequiredAssemblies",$moduleInfo.RequiredAssemblies)
+    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("RequiredAssemblies") -and $moduleInfo.RequiredAssemblies) {
+        $params.Add("RequiredAssemblies", $moduleInfo.RequiredAssemblies)
     }
 
-    if($FileList)
-    {
-        $params.Add("FileList",$FileList)
+    if ($FileList) {
+        $params.Add("FileList", $FileList)
     }
-    elseif($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("FileList") -and $moduleInfo.FileList)
-    {
-        $params.Add("FileList",$ModuleManifestHashTable.FileList)
+    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("FileList") -and $moduleInfo.FileList) {
+        $params.Add("FileList", $ModuleManifestHashTable.FileList)
     }
 
     #Make sure every path defined under FileList is within module base
     $moduleBase = $moduleInfo.ModuleBase
-    foreach($file in $params["FileList"])
-    {
+    foreach ($file in $params["FileList"]) {
         #If path is not root path, append the module base to it and check if the file exists
-        if(-not [System.IO.Path]::IsPathRooted($file))
-        {
+        if (-not [System.IO.Path]::IsPathRooted($file)) {
             $combinedPath = Join-Path $moduleBase -ChildPath $file
         }
-        else
-        {
+        else {
             $combinedPath = $file
         }
-        if(-not (Microsoft.PowerShell.Management\Test-Path -Type Leaf -LiteralPath $combinedPath))
-        {
-            $message = $LocalizedData.FilePathInFileListNotWithinModuleBase -f ($file,$moduleBase)
+        if (-not (Microsoft.PowerShell.Management\Test-Path -Type Leaf -LiteralPath $combinedPath)) {
+            $message = $LocalizedData.FilePathInFileListNotWithinModuleBase -f ($file, $moduleBase)
             ThrowError -ExceptionName "System.ArgumentException" `
-               -ExceptionMessage $message `
-               -ErrorId "FilePathInFileListNotWithinModuleBase" `
-               -ExceptionObject $file `
-               -CallerPSCmdlet $PSCmdlet `
-               -ErrorCategory InvalidArgument
+                -ExceptionMessage $message `
+                -ErrorId "FilePathInFileListNotWithinModuleBase" `
+                -ExceptionObject $file `
+                -CallerPSCmdlet $PSCmdlet `
+                -ErrorCategory InvalidArgument
 
             return
         }
     }
 
-    if($ModuleList)
-    {
-        $params.Add("ModuleList",$ModuleList)
+    if ($ModuleList) {
+        $params.Add("ModuleList", $ModuleList)
     }
-    elseif($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("ModuleList") -and $moduleInfo.ModuleList)
-    {
-        $params.Add("ModuleList",$ModuleManifestHashtable.ModuleList)
+    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("ModuleList") -and $moduleInfo.ModuleList) {
+        $params.Add("ModuleList", $ModuleManifestHashtable.ModuleList)
     }
 
-    if($FunctionsToExport -or $FunctionsToExport -is [array])
-    {
-        $params.Add("FunctionsToExport",$FunctionsToExport)
+    if ($FunctionsToExport -or $FunctionsToExport -is [array]) {
+        $params.Add("FunctionsToExport", $FunctionsToExport)
     }
-    elseif($moduleInfo.ExportedFunctions)
-    {
+    elseif ($moduleInfo.ExportedFunctions) {
         #Get the original module info from ManifestHashTable
-        if($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("FunctionsToExport") -and $ModuleManifestHashTable['FunctionsToExport'] -eq '*' `
-            -and $moduleInfo.ExportedFunctions.Keys.Count -eq 0)
-        {
+        if ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("FunctionsToExport") -and $ModuleManifestHashTable['FunctionsToExport'] -eq '*' `
+                -and $moduleInfo.ExportedFunctions.Keys.Count -eq 0) {
             $params.Add("FunctionsToExport", $ModuleManifestHashTable['FunctionsToExport'])
         }
-        elseif($moduleInfo.Prefix)
-        {
+        elseif ($moduleInfo.Prefix) {
             #Earlier call to Test-ModuleManifest adds prefix to functions, now those prefixes need to be remove
             #Prefixes are affixed to the beginning of function, or after '-'
-            $originalFunctions = $moduleInfo.ExportedFunctions.Keys | 
+            $originalFunctions = $moduleInfo.ExportedFunctions.Keys |
                 foreach-object { $parts = $_ -split '-', 2; $parts[-1] = $parts[-1] -replace "^$($moduleInfo.Prefix)"; $parts -join '-' }
             $params.Add("FunctionsToExport", $originalFunctions)
         }
-        else 
-        {
-            $params.Add("FunctionsToExport",($moduleInfo.ExportedFunctions.Keys -split ' '))
+        else {
+            $params.Add("FunctionsToExport", ($moduleInfo.ExportedFunctions.Keys -split ' '))
         }
     }
-    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("FunctionsToExport"))
-    {
+    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("FunctionsToExport")) {
         $params.Add("FunctionsToExport", $ModuleManifestHashTable['FunctionsToExport'])
     }
 
-    if($AliasesToExport -or $AliasesToExport -is [array])
-    {
-        $params.Add("AliasesToExport",$AliasesToExport)
+    if ($AliasesToExport -or $AliasesToExport -is [array]) {
+        $params.Add("AliasesToExport", $AliasesToExport)
     }
-    elseif($moduleInfo.ExportedAliases)
-    {
+    elseif ($moduleInfo.ExportedAliases) {
         #Get the original module info from ManifestHashTable
-        if($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("AliasesToExport") -and $ModuleManifestHashTable['AliasesToExport'] -eq '*' `
-            -and $moduleInfo.ExportedAliases.Keys.Count -eq 0)
-        {
+        if ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("AliasesToExport") -and $ModuleManifestHashTable['AliasesToExport'] -eq '*' `
+                -and $moduleInfo.ExportedAliases.Keys.Count -eq 0) {
             $params.Add("AliasesToExport", $ModuleManifestHashTable['AliasesToExport'])
         }
-        elseif($moduleInfo.Prefix)
-        {
+        elseif ($moduleInfo.Prefix) {
             #Earlier call to Test-ModuleManifest adds prefix to aliases, now those prefixes need to be removed
             #Prefixes are affixed to the beginning of function, or after '-'
-            $originalAliases = $moduleInfo.ExportedAliases.Keys | 
+            $originalAliases = $moduleInfo.ExportedAliases.Keys |
                 ForEach-Object { $parts = $_ -split '-', 2; $parts[-1] = $parts[-1] -replace "^$($moduleInfo.Prefix)"; $parts -join '-' }
-            $params.Add("AliasesToExport", $originalAliases)   
+            $params.Add("AliasesToExport", $originalAliases)
         }
-        else 
-        {
-            $params.Add("AliasesToExport",($moduleInfo.ExportedAliases.Keys -split ' '))
+        else {
+            $params.Add("AliasesToExport", ($moduleInfo.ExportedAliases.Keys -split ' '))
         }
     }
-    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("AliasesToExport"))
-    {
+    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("AliasesToExport")) {
         $params.Add("AliasesToExport", $ModuleManifestHashTable['AliasesToExport'])
     }
 
-    if($VariablesToExport)
-    {
-        $params.Add("VariablesToExport",$VariablesToExport)
+    if ($VariablesToExport) {
+        $params.Add("VariablesToExport", $VariablesToExport)
     }
-    elseif($moduleInfo.ExportedVariables)
-    {
-         #Get the original module info from ManifestHashTable
-        if($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("VariablesToExport") -and $ModuleManifestHashTable['VariablesToExport'] -eq '*' `
-            -and $moduleInfo.ExportedVariables.Keys.Count -eq 0)
-        {
+    elseif ($moduleInfo.ExportedVariables) {
+        #Get the original module info from ManifestHashTable
+        if ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("VariablesToExport") -and $ModuleManifestHashTable['VariablesToExport'] -eq '*' `
+                -and $moduleInfo.ExportedVariables.Keys.Count -eq 0) {
             $params.Add("VariablesToExport", $ModuleManifestHashTable['VariablesToExport'])
         }
         else {
             #Since $moduleInfo.ExportedAliases is a hashtable, we need to take the name of the
             #variables and make them into a list
-            $params.Add("VariablesToExport",($moduleInfo.ExportedVariables.Keys -split ' '))
+            $params.Add("VariablesToExport", ($moduleInfo.ExportedVariables.Keys -split ' '))
         }
     }
 
-    if($CmdletsToExport -or $CmdletsToExport -is [array])
-    {
+    if ($CmdletsToExport -or $CmdletsToExport -is [array]) {
         $params.Add("CmdletsToExport", $CmdletsToExport)
     }
-    elseif($moduleInfo.ExportedCmdlets)
-    {
+    elseif ($moduleInfo.ExportedCmdlets) {
         #Get the original module info from ManifestHashTable
-        if($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("CmdletsToExport") -and $ModuleManifestHashTable['CmdletsToExport'] -eq '*' `
-          -and $moduleInfo.ExportedCmdlets.Count -eq 0)
-        {
+        if ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("CmdletsToExport") -and $ModuleManifestHashTable['CmdletsToExport'] -eq '*' `
+                -and $moduleInfo.ExportedCmdlets.Count -eq 0) {
             $params.Add("CmdletsToExport", $ModuleManifestHashTable['CmdletsToExport'])
         }
-        elseif($moduleInfo.Prefix)
-        {
+        elseif ($moduleInfo.Prefix) {
             #Earlier call to Test-ModuleManifest adds prefix to cmdlets, now those prefixes need to be removed
             #Prefixes are affixed to the beginning of function, or after '-'
-            $originalCmdlets = $moduleInfo.ExportedCmdlets.Keys | 
+            $originalCmdlets = $moduleInfo.ExportedCmdlets.Keys |
                 ForEach-Object { $parts = $_ -split '-', 2; $parts[-1] = $parts[-1] -replace "^$($moduleInfo.Prefix)"; $parts -join '-' }
             $params.Add("CmdletsToExport", $originalCmdlets)
         }
-        else
-        {
-            $params.Add("CmdletsToExport",($moduleInfo.ExportedCmdlets.Keys -split ' '))
+        else {
+            $params.Add("CmdletsToExport", ($moduleInfo.ExportedCmdlets.Keys -split ' '))
         }
     }
-    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("CmdletsToExport"))
-    {
+    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("CmdletsToExport")) {
         $params.Add("CmdletsToExport", $ModuleManifestHashTable['CmdletsToExport'])
     }
 
-    if($DscResourcesToExport)
-    {
+    if ($DscResourcesToExport) {
         #DscResourcesToExport field is not available in PowerShell version lower than 5.0
 
-        if  (($PSVersionTable.PSVersion -lt '5.0.0') -or ($PowerShellVersion -and $PowerShellVersion -lt '5.0') `
-             -or (-not $PowerShellVersion -and $moduleInfo.PowerShellVersion -and $moduleInfo.PowerShellVersion -lt '5.0') `
-             -or (-not $PowerShellVersion -and -not $moduleInfo.PowerShellVersion))
-        {
-                ThrowError -ExceptionName "System.ArgumentException" `
-                   -ExceptionMessage $LocalizedData.ExportedDscResourcesNotSupportedOnLowerPowerShellVersion `
-                   -ErrorId "ExportedDscResourcesNotSupported" `
-                   -ExceptionObject $DscResourcesToExport `
-                   -CallerPSCmdlet $PSCmdlet `
-                   -ErrorCategory InvalidArgument
-                return
+        if (($PSVersionTable.PSVersion -lt '5.0.0') -or ($PowerShellVersion -and $PowerShellVersion -lt '5.0') `
+                -or (-not $PowerShellVersion -and $moduleInfo.PowerShellVersion -and $moduleInfo.PowerShellVersion -lt '5.0') `
+                -or (-not $PowerShellVersion -and -not $moduleInfo.PowerShellVersion)) {
+            ThrowError -ExceptionName "System.ArgumentException" `
+                -ExceptionMessage $LocalizedData.ExportedDscResourcesNotSupportedOnLowerPowerShellVersion `
+                -ErrorId "ExportedDscResourcesNotSupported" `
+                -ExceptionObject $DscResourcesToExport `
+                -CallerPSCmdlet $PSCmdlet `
+                -ErrorCategory InvalidArgument
+            return
         }
 
-        $params.Add("DscResourcesToExport",$DscResourcesToExport)
+        $params.Add("DscResourcesToExport", $DscResourcesToExport)
     }
-    elseif(Microsoft.PowerShell.Utility\Get-Member -InputObject $moduleInfo -name "ExportedDscResources")
-    {
-        if($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("DscResourcesToExport") -and $ModuleManifestHashTable['DscResourcesToExport'] -eq '*' `
-                -and $moduleInfo.ExportedDscResources.Count -eq 0)
-        {
-            $params.Add("DscResourcesToExport", $ModuleManifestHashTable['DscResourcesToExport']) 
+    elseif (Microsoft.PowerShell.Utility\Get-Member -InputObject $moduleInfo -name "ExportedDscResources") {
+        if ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("DscResourcesToExport") -and $ModuleManifestHashTable['DscResourcesToExport'] -eq '*' `
+                -and $moduleInfo.ExportedDscResources.Count -eq 0) {
+            $params.Add("DscResourcesToExport", $ModuleManifestHashTable['DscResourcesToExport'])
         }
-        else 
-        {
+        else {
             $params.Add("DscResourcesToExport", $moduleInfo.ExportedDscResources)
         }
     }
 
-    if($CompatiblePSEditions)
-    {
+    if ($CompatiblePSEditions) {
         # CompatiblePSEditions field is not available in PowerShell version lower than 5.1
         #
-        if  (($PSVersionTable.PSVersion -lt '5.1.0') -or ($PowerShellVersion -and $PowerShellVersion -lt '5.1') `
-             -or (-not $PowerShellVersion -and $moduleInfo.PowerShellVersion -and $moduleInfo.PowerShellVersion -lt '5.1') `
-             -or (-not $PowerShellVersion -and -not $moduleInfo.PowerShellVersion))
-        {
-                ThrowError -ExceptionName 'System.ArgumentException' `
-                           -ExceptionMessage $LocalizedData.CompatiblePSEditionsNotSupportedOnLowerPowerShellVersion `
-                           -ErrorId 'CompatiblePSEditionsNotSupported' `
-                           -ExceptionObject $CompatiblePSEditions `
-                           -CallerPSCmdlet $PSCmdlet `
-                           -ErrorCategory InvalidArgument
-                return
+        if (($PSVersionTable.PSVersion -lt '5.1.0') -or ($PowerShellVersion -and $PowerShellVersion -lt '5.1') `
+                -or (-not $PowerShellVersion -and $moduleInfo.PowerShellVersion -and $moduleInfo.PowerShellVersion -lt '5.1') `
+                -or (-not $PowerShellVersion -and -not $moduleInfo.PowerShellVersion)) {
+            ThrowError -ExceptionName 'System.ArgumentException' `
+                -ExceptionMessage $LocalizedData.CompatiblePSEditionsNotSupportedOnLowerPowerShellVersion `
+                -ErrorId 'CompatiblePSEditionsNotSupported' `
+                -ExceptionObject $CompatiblePSEditions `
+                -CallerPSCmdlet $PSCmdlet `
+                -ErrorCategory InvalidArgument
+            return
         }
 
         $params.Add('CompatiblePSEditions', $CompatiblePSEditions)
     }
-    elseif( (Microsoft.PowerShell.Utility\Get-Member -InputObject $moduleInfo -name 'CompatiblePSEditions') -and
-            $moduleInfo.CompatiblePSEditions)
-    {
+    elseif ( (Microsoft.PowerShell.Utility\Get-Member -InputObject $moduleInfo -name 'CompatiblePSEditions') -and
+        $moduleInfo.CompatiblePSEditions) {
         $params.Add('CompatiblePSEditions', $moduleInfo.CompatiblePSEditions)
     }
 
-    if($HelpInfoUri)
-    {
-        $params.Add("HelpInfoUri",$HelpInfoUri)
+    if ($HelpInfoUri) {
+        $params.Add("HelpInfoUri", $HelpInfoUri)
     }
-    elseif($moduleInfo.HelpInfoUri)
-    {
-        $params.Add("HelpInfoUri",$moduleInfo.HelpInfoUri)
+    elseif ($moduleInfo.HelpInfoUri) {
+        $params.Add("HelpInfoUri", $moduleInfo.HelpInfoUri)
     }
 
-    if($DefaultCommandPrefix)
-    {
-        $params.Add("DefaultCommandPrefix",$DefaultCommandPrefix)
+    if ($DefaultCommandPrefix) {
+        $params.Add("DefaultCommandPrefix", $DefaultCommandPrefix)
     }
-    elseif($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("DefaultCommandPrefix") -and $ModuleManifestHashTable.DefaultCommandPrefix)
-    {
-        $params.Add("DefaultCommandPrefix",$ModuleManifestHashTable.DefaultCommandPrefix)
+    elseif ($ModuleManifestHashTable -and $ModuleManifestHashTable.ContainsKey("DefaultCommandPrefix") -and $ModuleManifestHashTable.DefaultCommandPrefix) {
+        $params.Add("DefaultCommandPrefix", $ModuleManifestHashTable.DefaultCommandPrefix)
     }
 
     #Create a temp file within the directory and generate a new temporary manifest with the input
     $tempPath = Microsoft.PowerShell.Management\Join-Path -Path $moduleInfo.ModuleBase -ChildPath "PSGet_$($moduleInfo.Name).psd1"
-    $params.Add("Path",$tempPath)
+    $params.Add("Path", $tempPath)
 
-    try
-    {
+    try {
         #Terminates if there is error creating new module manifest
-        try{
+        try {
             Microsoft.PowerShell.Core\New-ModuleManifest @params -Confirm:$false -WhatIf:$false
             #If company name is the disposable name created for the new module manifest, it will be changed back to ''
-            (Get-Content -Path $tempPath) | ForEach-Object {$_ -Replace '__UPDATEDCOMPANYNAMETOBEREPLACEDINFUNCTION__', ''} | Set-Content -Path $tempPath -Confirm:$false -WhatIf:$false
+            (Get-Content -Path $tempPath) | ForEach-Object { $_ -Replace '__UPDATEDCOMPANYNAMETOBEREPLACEDINFUNCTION__', '' } | Set-Content -Path $tempPath -Confirm:$false -WhatIf:$false
         }
-        catch
-        {
+        catch {
             $ErrorMessage = $LocalizedData.UpdatedModuleManifestNotValid -f ($Path, $_.Exception.Message)
             ThrowError -ExceptionName "System.ArgumentException" `
-                       -ExceptionMessage $ErrorMessage `
-                       -ErrorId "NewModuleManifestFailure" `
-                       -ExceptionObject $params `
-                       -CallerPSCmdlet $PSCmdlet `
-                       -ErrorCategory InvalidArgument
+                -ExceptionMessage $ErrorMessage `
+                -ErrorId "NewModuleManifestFailure" `
+                -ExceptionObject $params `
+                -CallerPSCmdlet $PSCmdlet `
+                -ErrorCategory InvalidArgument
             return
         }
 
         #Manually update the section in PrivateData since New-ModuleManifest works differently on different PS version
         $PrivateDataInput = ""
         $ExistingData = $moduleInfo.PrivateData
-        $Data = @{}
-        if($ExistingData)
-        {
-            foreach($key in $ExistingData.Keys)
-            {
-                if($key -ne "PSData"){
-                    $Data.Add($key,$ExistingData[$key])
+        $Data = @{ }
+        if ($ExistingData) {
+            foreach ($key in $ExistingData.Keys) {
+                if ($key -ne "PSData") {
+                    $Data.Add($key, $ExistingData[$key])
                 }
-                else
-                {
+                else {
                     $PSData = $ExistingData["PSData"]
-                    foreach($entry in $PSData.Keys)
-                    {
-                        $Data.Add($entry,$PSData[$Entry])
+                    foreach ($entry in $PSData.Keys) {
+                        $Data.Add($entry, $PSData[$Entry])
                     }
                 }
             }
         }
 
-        if($PrivateData)
-        {
-            foreach($key in $PrivateData.Keys)
-            {
+        if ($PrivateData) {
+            foreach ($key in $PrivateData.Keys) {
                 #if user provides PSData within PrivateData, we will parse through the PSData
-                if($key -ne "PSData")
-                {
+                if ($key -ne "PSData") {
                     $Data[$key] = $PrivateData[$Key]
                 }
 
-                else
-                {
+                else {
                     $PSData = $ExistingData["PSData"]
-                    foreach($entry in $PSData.Keys)
-                    {
+                    foreach ($entry in $PSData.Keys) {
                         $Data[$entry] = $PSData[$entry]
                     }
                 }
@@ -742,42 +659,34 @@ function Update-ModuleManifest
         }
 
         #Tags is a read-only property
-        if($Tags)
-        {
-           $Data["Tags"] = $Tags
+        if ($Tags) {
+            $Data["Tags"] = $Tags
         }
 
         #The following Uris and ReleaseNotes cannot be empty
-        if($ProjectUri)
-        {
+        if ($ProjectUri) {
             $Data["ProjectUri"] = $ProjectUri
         }
 
-        if($LicenseUri)
-        {
+        if ($LicenseUri) {
             $Data["LicenseUri"] = $LicenseUri
         }
 
-        if($IconUri)
-        {
+        if ($IconUri) {
             $Data["IconUri"] = $IconUri
         }
-        if($RequireLicenseAcceptance)
-        {
+        if ($RequireLicenseAcceptance) {
             $Data["RequireLicenseAcceptance"] = $RequireLicenseAcceptance
         }
 
-        if($ReleaseNotes)
-        {
+        if ($ReleaseNotes) {
             #If value is provided as an array, we append the string.
             $Data["ReleaseNotes"] = $($ReleaseNotes -join "`r`n")
         }
 
-        if ($Prerelease)
-        {
+        if ($Prerelease) {
             $result = ValidateAndGet-VersionPrereleaseStrings -Version $params["ModuleVersion"] -Prerelease $Prerelease -CallerPSCmdlet $PSCmdlet
-            if (-not $result)
-            {
+            if (-not $result) {
                 # ValidateAndGet-VersionPrereleaseStrings throws the error.
                 # returning to avoid further execution when different values are specified for -ErrorAction parameter
                 return
@@ -786,33 +695,26 @@ function Update-ModuleManifest
             $Data[$script:Prerelease] = $validatedPrerelease
         }
 
-        if($ExternalModuleDependencies)
-        {
+        if ($ExternalModuleDependencies) {
             #ExternalModuleDependencies have to be specified either under $RequiredModules or $NestedModules
             #Extract all the module names specified in the moduleInfo of NestedModules and RequiredModules
             $DependentModuleNames = @()
-            foreach($moduleInfo in $params["NestedModules"])
-            {
-                if($moduleInfo.GetType() -eq [System.Collections.Hashtable])
-                {
+            foreach ($moduleInfo in $params["NestedModules"]) {
+                if ($moduleInfo.GetType() -eq [System.Collections.Hashtable]) {
                     $DependentModuleNames += $moduleInfo.ModuleName
                 }
             }
 
-            foreach($moduleInfo in $params["RequiredModules"])
-            {
-                if($moduleInfo.GetType() -eq [System.Collections.Hashtable])
-                {
+            foreach ($moduleInfo in $params["RequiredModules"]) {
+                if ($moduleInfo.GetType() -eq [System.Collections.Hashtable]) {
                     $DependentModuleNames += $moduleInfo.ModuleName
                 }
             }
 
-            foreach($dependency in $ExternalModuleDependencies)
-            {
-                if($params["NestedModules"] -notcontains $dependency -and
-                $params["RequiredModules"] -notContains $dependency -and
-                $DependentModuleNames -notcontains $dependency)
-                {
+            foreach ($dependency in $ExternalModuleDependencies) {
+                if ($params["NestedModules"] -notcontains $dependency -and
+                    $params["RequiredModules"] -notContains $dependency -and
+                    $DependentModuleNames -notcontains $dependency) {
                     $message = $LocalizedData.ExternalModuleDependenciesNotSpecifiedInRequiredOrNestedModules -f ($dependency)
                     ThrowError -ExceptionName "System.ArgumentException" `
                         -ExceptionMessage $message `
@@ -820,34 +722,29 @@ function Update-ModuleManifest
                         -ExceptionObject $Exception `
                         -CallerPSCmdlet $PSCmdlet `
                         -ErrorCategory InvalidArgument
-                        return
-                    }
+                    return
+                }
             }
-            if($Data.ContainsKey("ExternalModuleDependencies"))
-            {
+            if ($Data.ContainsKey("ExternalModuleDependencies")) {
                 $Data["ExternalModuleDependencies"] = $ExternalModuleDependencies
             }
-            else
-            {
+            else {
                 $Data.Add("ExternalModuleDependencies", $ExternalModuleDependencies)
             }
         }
-        if($PackageManagementProviders)
-        {
+        if ($PackageManagementProviders) {
             #Check if the provided value is within the relative path
             $ModuleBase = Microsoft.PowerShell.Management\Split-Path $Path -Parent
             $Files = Microsoft.PowerShell.Management\Get-ChildItem -Path $ModuleBase
-            foreach($provider in $PackageManagementProviders)
-            {
-                if ($Files.Name -notcontains $provider)
-                {
-                    $message = $LocalizedData.PackageManagementProvidersNotInModuleBaseFolder -f ($provider,$ModuleBase)
+            foreach ($provider in $PackageManagementProviders) {
+                if ($Files.Name -notcontains $provider) {
+                    $message = $LocalizedData.PackageManagementProvidersNotInModuleBaseFolder -f ($provider, $ModuleBase)
                     ThrowError -ExceptionName "System.ArgumentException" `
-                               -ExceptionMessage $message `
-                               -ErrorId "InvalidPackageManagementProviders" `
-                               -ExceptionObject $PackageManagementProviders `
-                               -CallerPSCmdlet $PSCmdlet `
-                               -ErrorCategory InvalidArgument
+                        -ExceptionMessage $message `
+                        -ErrorId "InvalidPackageManagementProviders" `
+                        -ExceptionObject $PackageManagementProviders `
+                        -CallerPSCmdlet $PSCmdlet `
+                        -ErrorCategory InvalidArgument
                     return
                 }
             }
@@ -863,115 +760,98 @@ function Update-ModuleManifest
         $newManifest = Microsoft.PowerShell.Management\Get-Content -Path $tempPath
         #Look up the endline of PrivateData section by finding the matching brackets since private data could
         #consist of multiple pairs of brackets.
-        $PrivateDataEndLine=0
-        if($PrivateDataBegin -match "@{")
-        {
+        $PrivateDataEndLine = 0
+        if ($PrivateDataBegin -match "@{") {
             $leftBrace = 0
-            $EndLineOfFile = $newManifest.Length-1
+            $EndLineOfFile = $newManifest.Length - 1
 
-            For($i = $PrivateDataBeginLine;$i -lt $EndLineOfFile; $i++)
-            {
-                if($newManifest[$i] -match "{")
-                {
+            For ($i = $PrivateDataBeginLine; $i -lt $EndLineOfFile; $i++) {
+                if ($newManifest[$i] -match "{") {
                     $leftBrace ++
                 }
-                elseif($newManifest[$i] -match "}")
-                {
-                    if($leftBrace -gt 0)
-                    {
+                elseif ($newManifest[$i] -match "}") {
+                    if ($leftBrace -gt 0) {
                         $leftBrace --
                     }
-                    else
-                    {
-                       $PrivateDataEndLine = $i
-                       break
+                    else {
+                        $PrivateDataEndLine = $i
+                        break
                     }
                 }
             }
         }
 
 
-        try
-        {
-            if($PrivateDataEndLine -ne 0)
-            {
+        try {
+            if ($PrivateDataEndLine -ne 0) {
                 #If PrivateData section has more than one line, we will remove the old content and insert the new PrivataData
-                $newManifest  | where {$_.readcount -le $PrivateDataBeginLine -or $_.readcount -gt $PrivateDataEndLine+1} `
+                $newManifest | where { $_.readcount -le $PrivateDataBeginLine -or $_.readcount -gt $PrivateDataEndLine + 1 } `
                 | ForEach-Object {
                     $_
-                    if($_ -match "PrivateData = ")
-                    {
+                    if ($_ -match "PrivateData = ") {
                         $PrivateDataInput
                     }
-                  } | Set-Content -Path $tempPath -Confirm:$false -WhatIf:$false
-            }
-
-            #In lower version, PrivateData is just a single line
-            else
-            {
-                $PrivateDataForDownlevelPS = "PrivateData = @{ `n"+$PrivateDataInput
-
-                $newManifest  | where {$_.readcount -le $PrivateDataBeginLine -or $_.readcount -gt $PrivateDataBeginLine } `
-                | ForEach-Object {
-                    $_
-                    if($_ -match "PrivateData = ")
-                    {
-                       $PrivateDataForDownlevelPS
-                    }
                 } | Set-Content -Path $tempPath -Confirm:$false -WhatIf:$false
-            }
-
-            #Verify the new module manifest is valid
-            $testModuleInfo = Microsoft.PowerShell.Core\Test-ModuleManifest -Path $tempPath `
-                                                                        -Verbose:$VerbosePreference ` -ErrorAction Stop
-        }
-        #Catch the exceptions from Test-ModuleManifest
-        catch
-        {
-            $message = $LocalizedData.UpdatedModuleManifestNotValid -f ($Path, $_.Exception.Message)
-
-            ThrowError -ExceptionName "System.ArgumentException" `
-                       -ExceptionMessage $message `
-                       -ErrorId "UpdateManifestFileFail" `
-                       -ExceptionObject $_.Exception `
-                       -CallerPSCmdlet $PSCmdlet `
-                       -ErrorCategory InvalidArgument
-            return
         }
 
+        #In lower version, PrivateData is just a single line
+        else {
+            $PrivateDataForDownlevelPS = "PrivateData = @{ `n" + $PrivateDataInput
 
-        $newContent = Microsoft.PowerShell.Management\Get-Content -Path $tempPath
-
-        #Remove the PSGet_ prepended to the original manifest name due to the temp file name
-        $newContent[1] = $newContent[1] -replace "'PSGet_", "'"
-
-        try
-        {
-            #Ask for confirmation of the new manifest before replacing the original one
-            if($PSCmdlet.ShouldProcess($Path,$LocalizedData.UpdateManifestContentMessage+$newContent))
-            {
-                Microsoft.PowerShell.Management\Set-Content -Path $Path -Value $newContent -Confirm:$false -WhatIf:$false
-            }
-
-            #Return the new content if -PassThru is specified
-            if($PassThru)
-            {
-                return $newContent
-            }
-        }
-        catch
-        {
-            $message = $LocalizedData.ManifestFileReadWritePermissionDenied -f ($Path)
-            ThrowError -ExceptionName "System.ArgumentException" `
-                        -ExceptionMessage $message `
-                        -ErrorId "ManifestFileReadWritePermissionDenied" `
-                        -ExceptionObject $Path `
-                        -CallerPSCmdlet $PSCmdlet `
-                        -ErrorCategory InvalidArgument
-        }
+            $newManifest | where { $_.readcount -le $PrivateDataBeginLine -or $_.readcount -gt $PrivateDataBeginLine } `
+            | ForEach-Object {
+                $_
+                if ($_ -match "PrivateData = ") {
+                    $PrivateDataForDownlevelPS
+                }
+            } | Set-Content -Path $tempPath -Confirm:$false -WhatIf:$false
     }
-    finally
-    {
-        Microsoft.PowerShell.Management\Remove-Item -LiteralPath $tempPath -Force -ErrorAction SilentlyContinue -WarningAction SilentlyContinue -Confirm:$false -WhatIf:$false
+
+    #Verify the new module manifest is valid
+    $testModuleInfo = Microsoft.PowerShell.Core\Test-ModuleManifest -Path $tempPath `
+        -Verbose:$VerbosePreference ` -ErrorAction Stop
+}
+#Catch the exceptions from Test-ModuleManifest
+catch {
+    $message = $LocalizedData.UpdatedModuleManifestNotValid -f ($Path, $_.Exception.Message)
+
+    ThrowError -ExceptionName "System.ArgumentException" `
+        -ExceptionMessage $message `
+        -ErrorId "UpdateManifestFileFail" `
+        -ExceptionObject $_.Exception `
+        -CallerPSCmdlet $PSCmdlet `
+        -ErrorCategory InvalidArgument
+    return
+}
+
+
+$newContent = Microsoft.PowerShell.Management\Get-Content -Path $tempPath
+
+#Remove the PSGet_ prepended to the original manifest name due to the temp file name
+$newContent[1] = $newContent[1] -replace "'PSGet_", "'"
+
+try {
+    #Ask for confirmation of the new manifest before replacing the original one
+    if ($PSCmdlet.ShouldProcess($Path, $LocalizedData.UpdateManifestContentMessage + $newContent)) {
+        Microsoft.PowerShell.Management\Set-Content -Path $Path -Value $newContent -Confirm:$false -WhatIf:$false
     }
+
+    #Return the new content if -PassThru is specified
+    if ($PassThru) {
+        return $newContent
+    }
+}
+catch {
+    $message = $LocalizedData.ManifestFileReadWritePermissionDenied -f ($Path)
+    ThrowError -ExceptionName "System.ArgumentException" `
+        -ExceptionMessage $message `
+        -ErrorId "ManifestFileReadWritePermissionDenied" `
+        -ExceptionObject $Path `
+        -CallerPSCmdlet $PSCmdlet `
+        -ErrorCategory InvalidArgument
+}
+}
+finally {
+    Microsoft.PowerShell.Management\Remove-Item -LiteralPath $tempPath -Force -ErrorAction SilentlyContinue -WarningAction SilentlyContinue -Confirm:$false -WhatIf:$false
+}
 }

--- a/src/PowerShellGet/public/psgetfunctions/Update-ModuleManifest.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Update-ModuleManifest.ps1
@@ -9,19 +9,10 @@ function Update-ModuleManifest {
     (
         [Parameter(Mandatory = $true,
             Position = 0,
-            ValueFromPipelineByPropertyName = $true,
-            ParameterSetName = "NameAndPathParameterSet")]
+            ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $Path,
-
-        [Parameter(Mandatory = $true,
-            ValueFromPipelineByPropertyName = $true,
-            ParameterSetName = "NameAndLiteralPathParameterSet")]
-        [ValidateNotNullOrEmpty()]
-        [Alias('PSPath')]
-        [string]
-        $LiteralPath,
 
         [ValidateNotNullOrEmpty()]
         [Object[]]
@@ -216,11 +207,6 @@ function Update-ModuleManifest {
 
 
     )
-
-    # If $Path is null, use the value of $literalpath
-    if (!$Path) {
-        $Path = $LiteralPath;
-    }
 
     if (-not (Microsoft.PowerShell.Management\Test-Path -Path $Path -PathType Leaf)) {
         $message = $LocalizedData.UpdateModuleManifestPathCannotFound -f ($Path)

--- a/src/PowerShellGet/public/psgetfunctions/Update-ModuleManifest.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Update-ModuleManifest.ps1
@@ -1,5 +1,4 @@
-function Update-ModuleManifest
-{
+function Update-ModuleManifest {
     <#
     .ExternalHelp PSModule-help.xml
     #>
@@ -9,6 +8,7 @@ function Update-ModuleManifest
     Param
     (
         [Parameter(Mandatory = $true,
+            Position = 0,
             ValueFromPipelineByPropertyName = $true,
             ParameterSetName = "NameAndPathParameterSet")]
         [ValidateNotNullOrEmpty()]
@@ -218,11 +218,10 @@ function Update-ModuleManifest
     )
 
     # If $Path is null, use the value of $literalpath
-    if (!$Path)
-    {
+    if (!$Path) {
         $Path = $LiteralPath;
     }
-       
+
     if (-not (Microsoft.PowerShell.Management\Test-Path -Path $Path -PathType Leaf)) {
         $message = $LocalizedData.UpdateModuleManifestPathCannotFound -f ($Path)
         ThrowError -ExceptionName "System.ArgumentException" `


### PR DESCRIPTION
Modified the functions to include the LiteralPath parameter. If Path parameter is null, then the value in LiteralPath is assigned to Path. Every thing else remains same.