### PR TITLE
Mlonis fix for issue 165

### DIFF
--- a/src/PowerShellGet/private/functions/Get-PSScriptInfoString.ps1
+++ b/src/PowerShellGet/private/functions/Get-PSScriptInfoString.ps1
@@ -87,14 +87,13 @@ function Get-PSScriptInfoString
 
 .ICONURI$(if ($IconUri) {" $IconUri"})
 
-.EXTERNALMODULEDEPENDENCIES$(if ($ExternalModuleDependencies) {" $($ExternalModuleDependencies -join ',')"}) 
+.EXTERNALMODULEDEPENDENCIES$(if ($ExternalModuleDependencies) {" $($ExternalModuleDependencies -join ',')"})
 
 .REQUIREDSCRIPTS$(if ($RequiredScripts) {" $($RequiredScripts -join ',')"})
 
 .EXTERNALSCRIPTDEPENDENCIES$(if ($ExternalScriptDependencies) {" $($ExternalScriptDependencies -join ',')"})
 
-.RELEASENOTES
-$($ReleaseNotes -join "`r`n")
+.RELEASENOTES$(if ($ReleaseNotes) {`r`n$($ReleaseNotes -join "`r`n")})
 
 .PRIVATEDATA$(if ($PrivateData) {" $PrivateData"})
 

--- a/src/PowerShellGet/private/functions/Get-ScriptCommentHelpInfoString.ps1
+++ b/src/PowerShellGet/private/functions/Get-ScriptCommentHelpInfoString.ps1
@@ -47,11 +47,11 @@ function Get-ScriptCommentHelpInfoString
 
     Process
     {
-        $ScriptCommentHelpInfoString = "<# `r`n`r`n.DESCRIPTION `r`n $Description `r`n`r`n"
+        $ScriptCommentHelpInfoString = "<#`r`n`r`n.DESCRIPTION`r`n$Description`r`n`r`n"
 
         if("$Synopsis".Trim())
         {
-            $ScriptCommentHelpInfoString += ".SYNOPSIS `r`n$Synopsis `r`n`r`n"
+            $ScriptCommentHelpInfoString += ".SYNOPSIS`r`n$Synopsis`r`n`r`n"
         }
 
         if("$Example".Trim())
@@ -59,7 +59,7 @@ function Get-ScriptCommentHelpInfoString
             $Example | ForEach-Object {
                            if($_)
                            {
-                               $ScriptCommentHelpInfoString += ".EXAMPLE `r`n$_ `r`n`r`n"
+                               $ScriptCommentHelpInfoString += ".EXAMPLE`r`n$_`r`n`r`n"
                            }
                        }
         }
@@ -69,7 +69,7 @@ function Get-ScriptCommentHelpInfoString
             $Inputs |  ForEach-Object {
                            if($_)
                            {
-                               $ScriptCommentHelpInfoString += ".INPUTS `r`n$_ `r`n`r`n"
+                               $ScriptCommentHelpInfoString += ".INPUTS`r`n$_`r`n`r`n"
                            }
                        }
         }
@@ -79,14 +79,14 @@ function Get-ScriptCommentHelpInfoString
             $Outputs |  ForEach-Object {
                            if($_)
                            {
-                               $ScriptCommentHelpInfoString += ".OUTPUTS `r`n$_ `r`n`r`n"
+                               $ScriptCommentHelpInfoString += ".OUTPUTS`r`n$_`r`n`r`n"
                            }
                        }
         }
 
         if("$Notes".Trim())
         {
-            $ScriptCommentHelpInfoString += ".NOTES `r`n$($Notes -join "`r`n") `r`n`r`n"
+            $ScriptCommentHelpInfoString += ".NOTES`r`n$($Notes -join "`r`n")`r`n`r`n"
         }
 
         if("$Link".Trim())
@@ -94,27 +94,27 @@ function Get-ScriptCommentHelpInfoString
             $Link |  ForEach-Object {
                          if($_)
                          {
-                              $ScriptCommentHelpInfoString += ".LINK `r`n$_ `r`n`r`n"
+                              $ScriptCommentHelpInfoString += ".LINK`r`n$_`r`n`r`n"
                          }
                      }
         }
 
         if("$Component".Trim())
         {
-            $ScriptCommentHelpInfoString += ".COMPONENT `r`n$($Component -join "`r`n") `r`n`r`n"
+            $ScriptCommentHelpInfoString += ".COMPONENT`r`n$($Component -join "`r`n")`r`n`r`n"
         }
 
         if("$Role".Trim())
         {
-            $ScriptCommentHelpInfoString += ".ROLE `r`n$($Role -join "`r`n") `r`n`r`n"
+            $ScriptCommentHelpInfoString += ".ROLE`r`n$($Role -join "`r`n")`r`n`r`n"
         }
 
         if("$Functionality".Trim())
         {
-            $ScriptCommentHelpInfoString += ".FUNCTIONALITY `r`n$($Functionality -join "`r`n") `r`n`r`n"
+            $ScriptCommentHelpInfoString += ".FUNCTIONALITY`r`n$($Functionality -join "`r`n")`r`n`r`n"
         }
 
-        $ScriptCommentHelpInfoString += "#> `r`n"
+        $ScriptCommentHelpInfoString += "#>`r`n"
 
         return $ScriptCommentHelpInfoString
     }

--- a/src/PowerShellGet/public/psgetfunctions/Update-ScriptFileInfo.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Update-ScriptFileInfo.ps1
@@ -396,7 +396,7 @@ function Update-ScriptFileInfo {
                             $PSScriptInfoString = $PSScriptInfoString.TrimStart()
                             $requiresStrings = $requiresStrings.TrimEnd()
 
-                            if ("$requiresStrings".Trim()) {
+                            if ($requiresStrings.Trim() -ne "") {
                                 $tempContents += "$PSScriptInfoString`r`n`r`n$($requiresStrings -join "`r`n")"
                             } else {
                                 $tempContents += $PSScriptInfoString

--- a/src/PowerShellGet/public/psgetfunctions/Update-ScriptFileInfo.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Update-ScriptFileInfo.ps1
@@ -396,13 +396,23 @@ function Update-ScriptFileInfo {
                             $PSScriptInfoString = $PSScriptInfoString.TrimStart()
                             $requiresStrings = $requiresStrings.TrimEnd()
 
-                            $tempContents += "$PSScriptInfoString `r`n`r`n$($requiresStrings -join "`r`n")"
+                            if ("$requiresStrings".Trim()) {
+                                $tempContents += "$PSScriptInfoString`r`n`r`n$($requiresStrings -join "`r`n")"
+                            } else {
+                                $tempContents += $PSScriptInfoString
+                            }
                             $IsNewPScriptInfoAdded = $true
                         }
                     }
                     elseif ($line -notmatch "\s*#Requires\s+-Module") {
                         # Add the existing lines if they are not part of PSScriptInfo comment or not containing #Requires -Module statements.
                         $tempContents += $line
+                    } elseif (($scriptFileContents[$i + 1] -eq "`r`n" -or $scriptFileContents[$i + 1] -eq "") -and (($i + 1) -lt $scriptFileContents.Count)) {
+                        # This condition will only be met if the line is a Requires -Module statement.
+                        # To adding newlines everytime the function is called on a script, we must increment i by 1
+                        # if the next line after the caught Requires -Module statement is the empty string or a `r`n
+                        # This prevents extra newlines from being inserted
+                        $i = $i + 1
                     }
                 }
 
@@ -441,7 +451,7 @@ function Update-ScriptFileInfo {
 
                                 if ($line.Trim().StartsWith("#>", [System.StringComparison]::OrdinalIgnoreCase) -or
                                     $line.Trim().StartsWith(".", [System.StringComparison]::OrdinalIgnoreCase)) {
-                                    $tempContents += ".DESCRIPTION `r`n$($Description -join "`r`n")`r`n"
+                                    $tempContents += ".DESCRIPTION`r`n$($Description -join "`r`n")`r`n"
                                     $IsDescriptionAdded = $true
                                     $tempContents += $line
                                 }


### PR DESCRIPTION
# Description

This pull request resolves issue #165 .

## Changelog

### Get-PSScriptInfoString.ps1

1. Removed the trailing whitespace on line 90.
1. Refactored lines 96-97 as a singular line of code. This change functions just like the code before but, when $ReleaseNotes is the empty string, it will no longer add an extra newline when the release notes section is being left empty.

### Get-ScriptCommentHelpInfoString.ps1

1. Modified line 50, 54, 62, 72, 82, 89, 97, 104, 109, 114, & 117 to remove the trailing whitespaces when creating the comment help info string.

### Update-ScriptFileInfo.ps1

1. Modified line 399 to no longer add a character return newline sequence when the $requiresString is the empty string.
1. Modified line 405 to no longer add a character return newline sequence when a script already has Requires -Module statements but the update function is not looking to add any new Requires -Module statements.
1. Modified line 444 to remove the trailing whitespace after the word DESCRIPTION in the script info.