### PR TITLE
Fixing Publish Failure (#510) 

### DIFF
--- a/src/PowerShellGet/private/functions/New-NugetPackage.ps1
+++ b/src/PowerShellGet/private/functions/New-NugetPackage.ps1
@@ -116,8 +116,7 @@ function New-NugetPackage {
         throw "$ProcessName failed to pack: error $errors"
     }
 
-    $stdOut -match "Successfully created package '(.*.nupkg)'" | Out-Null
-    $nupkgFullFile = $matches[1]
+    $nupkgFullFile = Get-ChildItem -Path $OutputPath -Filter *.nupkg
 
     Write-Verbose "Created Nuget Package $nupkgFullFile"
     Write-Output $nupkgFullFile

--- a/src/PowerShellGet/private/functions/New-NugetPackage.ps1
+++ b/src/PowerShellGet/private/functions/New-NugetPackage.ps1
@@ -119,5 +119,5 @@ function New-NugetPackage {
     $nupkgFullFile = Get-ChildItem -Path $OutputPath -Filter *.nupkg
 
     Write-Verbose "Created Nuget Package $nupkgFullFile"
-    Write-Output $nupkgFullFile
+    Write-Output $nupkgFullFile.FullName
 }


### PR DESCRIPTION
Publish fails on poor searching of a nupkg file.
The issue is reported [here](https://github.com/PowerShell/PowerShellGet/issues/510).
On non en-US environments, MSBuild produces culture variant message. `New-NugetPackage` relies on the English string.

![obrazek](https://user-images.githubusercontent.com/8374320/71451330-4294ed00-2773-11ea-8546-ad3d9d6a9f98.png)

The main problem here is a wrong perspective. 
We are dealing with a file path as a `string` not as a `FileIO` instance.
