### PR TITLE
Passing proxy info along when registering default repository

### DIFF
--- a/src/PowerShellGet/public/providerfunctions/Add-PackageSource.ps1
+++ b/src/PowerShellGet/public/providerfunctions/Add-PackageSource.ps1
@@ -247,7 +247,7 @@ function Add-PackageSource
     if($Name -eq $Script:PSGalleryModuleSource)
     {
         # Add or update the PSGallery repository
-        $repository = Set-PSGalleryRepository -Trusted:$Trusted
+        $repository = Set-PSGalleryRepository -Trusted:$Trusted -Proxy $Proxy -ProxyCredential $ProxyCredential
 
         if($repository)
         {


### PR DESCRIPTION
I'm not sure if this was just an oversight or if it was intentionally left out, but if I specify -Proxy and/or -ProxyCredentials when calling Register-PSRepository -Default, they get ignored because they don't get passed along here.  In PowerShell 6 this makes it impossible to register PS Gallery behind a proxy, since you can't set the default proxy on HttpClient.

I'm not super familiar with PowerShell testing, but it didn't look like we were doing mock/expect type testing, and setting a proxy value for real would always fail unless there was in fact a proxy running.  If there is a place/approach I should use to test this, let me know and I'll try to get it added.