### PR TITLE
Add enforcement of TLS1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+### 2.2.4
+- Enforce a security protocol of TLS 1.2 when interacting with online repositories (#598)
+
 ### 2.2.3
 
 - Update `HelpInfoUri` to point to the latest content (#560)

--- a/src/PowerShellGet/PowerShellGet.psd1
+++ b/src/PowerShellGet/PowerShellGet.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'PSModule.psm1'
-    ModuleVersion     = '2.2.3'
+    ModuleVersion     = '2.2.4'
     GUID              = '1d73a601-4a6c-43c5-ba3f-619b18bbb404'
     Author            = 'Microsoft Corporation'
     CompanyName       = 'Microsoft Corporation'

--- a/src/PowerShellGet/public/psgetfunctions/Find-Module.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Find-Module.ps1
@@ -90,6 +90,10 @@ function Find-Module {
     )
 
     Begin {
+        # Change security protocol to TLS 1.2
+        $script:securityProtocol = [Net.ServicePointManager]::SecurityProtocol
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
         Install-NuGetClientBinaries -CallerPSCmdlet $PSCmdlet -Proxy $Proxy -ProxyCredential $ProxyCredential
     }
 
@@ -158,12 +162,13 @@ function Find-Module {
                 else {
                     $psgetItemInfo
                 }
-            } elseif ($PSBoundParameters['Name'] -and -not (Test-WildcardPattern -Name ($Name | Microsoft.PowerShell.Core\Where-Object { $psgetItemInfo.Name -like $_ }))) {
+            }
+            elseif ($PSBoundParameters['Name'] -and -not (Test-WildcardPattern -Name ($Name | Microsoft.PowerShell.Core\Where-Object { $psgetItemInfo.Name -like $_ }))) {
                 $message = $LocalizedData.MatchInvalidType -f ($psgetItemInfo.Name, $psgetItemInfo.Type, $script:PSArtifactTypeModule)
                 Write-Error -Message $message `
-                            -ErrorId 'MatchInvalidType' `
-                            -Category InvalidArgument `
-                            -TargetObject $Name
+                    -ErrorId 'MatchInvalidType' `
+                    -Category InvalidArgument `
+                    -TargetObject $Name
             }
 
             if ($psgetItemInfo -and
@@ -180,5 +185,10 @@ function Find-Module {
         if ($isRepositoryNullOrPSGallerySpecified) {
             Log-ArtifactNotFoundInPSGallery -SearchedName $Name -FoundName $modulesFoundInPSGallery -operationName 'PSGET_FIND_MODULE'
         }
+    }
+
+    End {
+        # Change back to user specified security protocol
+        [Net.ServicePointManager]::SecurityProtocol = $script:securityProtocol
     }
 }

--- a/src/PowerShellGet/public/psgetfunctions/Find-Script.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Find-Script.ps1
@@ -80,6 +80,10 @@ function Find-Script {
     )
 
     Begin {
+        # Change security protocol to TLS 1.2
+        $script:securityProtocol = [Net.ServicePointManager]::SecurityProtocol
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
         Install-NuGetClientBinaries -CallerPSCmdlet $PSCmdlet -Proxy $Proxy -ProxyCredential $ProxyCredential
     }
 
@@ -166,12 +170,13 @@ function Find-Script {
                 else {
                     $psgetItemInfo
                 }
-            } elseif ($PSBoundParameters['Name'] -and -not (Test-WildcardPattern -Name ($Name | Microsoft.PowerShell.Core\Where-Object { $psgetItemInfo.Name -like $_ }))) {
+            }
+            elseif ($PSBoundParameters['Name'] -and -not (Test-WildcardPattern -Name ($Name | Microsoft.PowerShell.Core\Where-Object { $psgetItemInfo.Name -like $_ }))) {
                 $message = $LocalizedData.MatchInvalidType -f ($psgetItemInfo.Name, $psgetItemInfo.Type, $script:PSArtifactTypeScript)
                 Write-Error -Message $message `
-                            -ErrorId 'MatchInvalidType' `
-                            -Category InvalidArgument `
-                            -TargetObject $Name
+                    -ErrorId 'MatchInvalidType' `
+                    -Category InvalidArgument `
+                    -TargetObject $Name
             }
 
             if ($psgetItemInfo -and
@@ -187,5 +192,10 @@ function Find-Script {
         if ($isRepositoryNullOrPSGallerySpecified) {
             Log-ArtifactNotFoundInPSGallery -SearchedName $Name -FoundName $scriptsFoundInPSGallery -operationName PSGET_FIND_SCRIPT
         }
+    }
+
+    End {
+        # Change back to user specified security protocol
+        [Net.ServicePointManager]::SecurityProtocol = $script:securityProtocol
     }
 }

--- a/src/PowerShellGet/public/psgetfunctions/Install-Module.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Install-Module.ps1
@@ -91,6 +91,10 @@ function Install-Module {
     )
 
     Begin {
+        # Change security protocol to TLS 1.2
+        $script:securityProtocol = [Net.ServicePointManager]::SecurityProtocol
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
         if ($Scope -eq "AllUsers" -and -not (Test-RunningAsElevated)) {
             # Throw an error when Install-Module is used as a non-admin user and '-Scope AllUsers'
             $message = $LocalizedData.InstallModuleAdminPrivilegeRequiredForAllUsersScope -f @($script:programFilesModulesPath, $script:MyDocumentsModulesPath)
@@ -268,5 +272,10 @@ function Install-Module {
                 }
             }
         }
+    }
+
+    End {
+        # Change back to user specified security protocol
+        [Net.ServicePointManager]::SecurityProtocol = $script:securityProtocol
     }
 }

--- a/src/PowerShellGet/public/psgetfunctions/Install-Script.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Install-Script.ps1
@@ -87,6 +87,10 @@ function Install-Script {
     )
 
     Begin {
+        # Change security protocol to TLS 1.2
+        $script:securityProtocol = [Net.ServicePointManager]::SecurityProtocol
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
         if ($Scope -eq "AllUsers" -and -not (Test-RunningAsElevated)) {
             # Throw an error when Install-Script is used as a non-admin user and '-Scope AllUsers'
             $message = $LocalizedData.InstallScriptAdminPrivilegeRequiredForAllUsersScope -f @($script:ProgramFilesScriptsPath, $script:MyDocumentsScriptsPath)
@@ -317,5 +321,10 @@ function Install-Script {
                 }
             }
         }
+    }
+
+    End {
+        # Change back to user specified security protocol
+        [Net.ServicePointManager]::SecurityProtocol = $script:securityProtocol
     }
 }

--- a/src/PowerShellGet/public/psgetfunctions/Publish-Script.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Publish-Script.ps1
@@ -43,6 +43,10 @@ function Publish-Script {
     )
 
     Begin {
+        # Change security protocol to TLS 1.2
+        $script:securityProtocol = [Net.ServicePointManager]::SecurityProtocol
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
         Install-NuGetClientBinaries -CallerPSCmdlet $PSCmdlet -BootstrapNuGetExe -Force:$Force
     }
 
@@ -335,5 +339,10 @@ function Publish-Script {
         finally {
             Microsoft.PowerShell.Management\Remove-Item $tempScriptPath -Force -Recurse -ErrorAction Ignore -WarningAction SilentlyContinue -Confirm:$false -WhatIf:$false
         }
+    }
+
+    End {
+        # Change back to user specified security protocol
+        [Net.ServicePointManager]::SecurityProtocol = $script:securityProtocol
     }
 }

--- a/src/PowerShellGet/public/psgetfunctions/Save-Module.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Save-Module.ps1
@@ -114,6 +114,10 @@ function Save-Module {
     )
 
     Begin {
+        # Change security protocol to TLS 1.2
+        $script:securityProtocol = [Net.ServicePointManager]::SecurityProtocol
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
         Install-NuGetClientBinaries -CallerPSCmdlet $PSCmdlet -Proxy $Proxy -ProxyCredential $ProxyCredential
 
         # Module names already tried in the current pipeline for InputObject parameterset
@@ -251,5 +255,10 @@ function Save-Module {
                 $null = PackageManagement\Save-Package @PSBoundParameters
             }
         }
+    }
+
+    End {
+        # Change back to user specified security protocol
+        [Net.ServicePointManager]::SecurityProtocol = $script:securityProtocol
     }
 }

--- a/src/PowerShellGet/public/psgetfunctions/Save-Script.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Save-Script.ps1
@@ -116,6 +116,10 @@ function Save-Script {
     )
 
     Begin {
+        # Change security protocol to TLS 1.2
+        $script:securityProtocol = [Net.ServicePointManager]::SecurityProtocol
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
         Install-NuGetClientBinaries -CallerPSCmdlet $PSCmdlet -Proxy $Proxy -ProxyCredential $ProxyCredential
 
         # Script names already tried in the current pipeline for InputObject parameterset
@@ -257,5 +261,10 @@ function Save-Script {
                 $null = PackageManagement\Save-Package @PSBoundParameters
             }
         }
+    }
+
+    End {
+        # Change back to user specified security protocol
+        [Net.ServicePointManager]::SecurityProtocol = $script:securityProtocol
     }
 }

--- a/src/PowerShellGet/public/psgetfunctions/Update-Module.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Update-Module.ps1
@@ -58,6 +58,10 @@ function Update-Module {
     )
 
     Begin {
+        # Change security protocol to TLS 1.2
+        $script:securityProtocol = [Net.ServicePointManager]::SecurityProtocol
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
         Install-NuGetClientBinaries -CallerPSCmdlet $PSCmdlet -Proxy $Proxy -ProxyCredential $ProxyCredential
 
         if ($Scope -eq "AllUsers" -and -not (Test-RunningAsElevated)) {
@@ -168,5 +172,10 @@ function Update-Module {
                 $sid | Microsoft.PowerShell.Core\ForEach-Object { New-PSGetItemInfo -SoftwareIdentity $_ -Type $script:PSArtifactTypeModule }
             }
         }
+    }
+
+    End {
+        # Change back to user specified security protocol
+        [Net.ServicePointManager]::SecurityProtocol = $script:securityProtocol
     }
 }

--- a/src/PowerShellGet/public/psgetfunctions/Update-Script.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Update-Script.ps1
@@ -53,6 +53,10 @@ function Update-Script {
     )
 
     Begin {
+        # Change security protocol to TLS 1.2
+        $script:securityProtocol = [Net.ServicePointManager]::SecurityProtocol
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
         Install-NuGetClientBinaries -CallerPSCmdlet $PSCmdlet -Proxy $Proxy -ProxyCredential $ProxyCredential
 
         # Script names already tried in the current pipeline
@@ -175,5 +179,10 @@ function Update-Script {
                 $sid | Microsoft.PowerShell.Core\ForEach-Object { New-PSGetItemInfo -SoftwareIdentity $_ -Type $script:PSArtifactTypeScript }
             }
         }
+    }
+
+    End {
+        # Change back to user specified security protocol
+        [Net.ServicePointManager]::SecurityProtocol = $script:securityProtocol
     }
 }


### PR DESCRIPTION
Due to the PowerShell Gallery needing to enforce TLS 1.2, we've had a number of complaints from those still using lower versions.  Additions in this PR will save the user's current security protocol settings, then change the security protocol to TLS 1.2 in order to send requests via the updated version, then revert the security protocol back to the user's setting before the request was sent. 