### PR TITLE
Remove catalog file and up version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+### 2.2.4.1
+- Remove catalog file
+
 ### 2.2.4
 - Enforce a security protocol of TLS 1.2 when interacting with online repositories (#598)
 

--- a/SignCat.xml
+++ b/SignCat.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-
-<!-- Config files for Azure DevOps code-signing pipeline. -->
-<SignConfigXML>
-  <!-- AnyCPU Release sign job -->
-  <job platform="AnyCPU" configuration="Release" dest="__OUTPATHROOT__\signed" jobname="PowerShellGet" approvers="americks;edyoung">
-    <file src="__INPATHROOT__\PowerShellGet.cat" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\PowerShellGet.cat" />
-  </job>
-</SignConfigXML>

--- a/src/PowerShellGet/PowerShellGet.psd1
+++ b/src/PowerShellGet/PowerShellGet.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'PSModule.psm1'
-    ModuleVersion     = '2.2.4'
+    ModuleVersion     = '2.2.4.1'
     GUID              = '1d73a601-4a6c-43c5-ba3f-619b18bbb404'
     Author            = 'Microsoft Corporation'
     CompanyName       = 'Microsoft Corporation'
@@ -55,6 +55,9 @@
             ProjectUri   = 'https://go.microsoft.com/fwlink/?LinkId=828955'
             LicenseUri   = 'https://go.microsoft.com/fwlink/?LinkId=829061'
             ReleaseNotes = @'
+### 2.2.4.1
+- Remove catalog file
+
 ### 2.2.3
 - Update `HelpInfoUri` to point to the latest content (#560)
 - Improve discovery of usable nuget.exe binary (Thanks bwright86!) (#558)


### PR DESCRIPTION
Catalog file is a relic from older days when it was used a fix for a Windows component.  It's no longer adding any value and can causes problems with installations.