### PR TITLE
Add tab completion for -Name parameter of Set-PSRepository

### DIFF
--- a/src/PowerShellGet/private/modulefile/PartTwo.ps1
+++ b/src/PowerShellGet/private/modulefile/PartTwo.ps1
@@ -38,7 +38,8 @@ $commandsWithRepositoryParameter = @(
     "Save-Script")
 
 $commandsWithRepositoryAsName = @(
-    "Get-PSRepository",
+    "Get-PSRepository"
+    "Set-PSRepository"
     "Register-PSRepository"
     "Unregister-PSRepository"
 )


### PR DESCRIPTION
This command seems to have been missed out in the list.
Also remove redundant comma after `Get-PSRepository`, in a multi-line array commas are not needed.
cc @alerickson 