### PR TITLE
Replace STDOut parsing with file lookup

### DIFF
--- a/src/PowerShellGet/private/functions/New-NugetPackage.ps1
+++ b/src/PowerShellGet/private/functions/New-NugetPackage.ps1
@@ -116,8 +116,8 @@ function New-NugetPackage {
         throw "$ProcessName failed to pack: error $errors"
     }
 
-    $stdOut -match "Successfully created package '(.*.nupkg)'" | Out-Null
-    $nupkgFullFile = $matches[1]
+    $nupkgFiles = Get-ChildItem $OutputPath -Filter "*.nupkg";
+    $nupkgFullFile = $nupkgFiles[0].FullName
 
     Write-Verbose "Created Nuget Package $nupkgFullFile"
     Write-Output $nupkgFullFile


### PR DESCRIPTION
stdOut parsing will fail on machines using non en-US locale.
So I replaced stdOut parsing with looking for the "*.nupkg" in $OutputPath.

Should fix #597 